### PR TITLE
escape $ sign that is preserved for tab stops in snippet strings and remove the tabstop if there is no suffix

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -179,7 +179,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
   }
   function escapeTabStopSign(value){
-    return value.replace("$","\\$");
+    return value.replace(new RegExp("\\$", 'g'), "\\$");
   }
 
   function isMarkdownStringSpec(x: any): x is MarkdownStringSpec {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,9 +142,9 @@ export function activate(context: vscode.ExtensionContext) {
     let item = new vscode.CompletionItem(args.entry.new_prefix);
     item.sortText = new Array(args.index + 2).join('0');
     
-    item.insertText = new vscode.SnippetString(args.entry.new_prefix)
+    item.insertText = new vscode.SnippetString(escapeTabstopSign(args.entry.new_prefix))
       .appendTabstop()
-      .appendText(args.entry.new_suffix);
+      .appendText(escapeTabstopSign(args.entry.new_suffix));
 
     item.range = new vscode.Range(args.position.translate(0, -args.old_prefix.length), args.position.translate(0, args.entry.old_suffix.length));
     if (args.entry.documentation) {
@@ -174,6 +174,9 @@ export function activate(context: vscode.ExtensionContext) {
     } else {
       return documentation;
     }
+  }
+  function escapeTabstopSign(value){
+    return value.replace("$","\\$");
   }
 
   function isMarkdownStringSpec(x: any): x is MarkdownStringSpec {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -140,11 +140,14 @@ export function activate(context: vscode.ExtensionContext) {
     : vscode.CompletionItem
   {
     let item = new vscode.CompletionItem(args.entry.new_prefix);
-    item.sortText = new Array(args.index + 2).join('0');
+    item.sortText = new Array(args.index + 2).join("0");
+    item.insertText = new vscode.SnippetString(escapeTabStopSign(args.entry.new_prefix));
+    if (args.entry.new_suffix) {
+      item.insertText
+        .appendTabstop()
+        .appendText(escapeTabStopSign(args.entry.new_suffix));
+    }
     
-    item.insertText = new vscode.SnippetString(escapeTabstopSign(args.entry.new_prefix))
-      .appendTabstop()
-      .appendText(escapeTabstopSign(args.entry.new_suffix));
 
     item.range = new vscode.Range(args.position.translate(0, -args.old_prefix.length), args.position.translate(0, args.entry.old_suffix.length));
     if (args.entry.documentation) {
@@ -175,7 +178,7 @@ export function activate(context: vscode.ExtensionContext) {
       return documentation;
     }
   }
-  function escapeTabstopSign(value){
+  function escapeTabStopSign(value){
     return value.replace("$","\\$");
   }
 


### PR DESCRIPTION
- escape $ sign that is preserved for tab stops in snippet strings.
- remove the tabstop if there is no suffix - otherwise it will mark the text after the inserted snippet as selected.

**first issue:**

![escape-tab-stop](https://user-images.githubusercontent.com/60742964/76678077-8d3d3d00-65dd-11ea-9601-629cb4906776.gif)

**second issue:**

![selected-text](https://user-images.githubusercontent.com/60742964/76681844-cc7c8580-65ff-11ea-8913-aa55a2edac01.gif)

