### PR TITLE
fix snippet text selection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,7 +144,7 @@ export function activate(context: vscode.ExtensionContext) {
     item.insertText = new vscode.SnippetString(escapeTabStopSign(args.entry.new_prefix));
     if (args.entry.new_suffix) {
       item.insertText
-        .appendTabstop()
+        .appendTabstop(0)
         .appendText(escapeTabStopSign(args.entry.new_suffix));
     }
     
@@ -181,7 +181,6 @@ export function activate(context: vscode.ExtensionContext) {
   function escapeTabStopSign(value){
     return value.replace(new RegExp("\\$", 'g'), "\\$");
   }
-
   function isMarkdownStringSpec(x: any): x is MarkdownStringSpec {
     return x.kind;
   }


### PR DESCRIPTION
fix tab stop to end the selection after the first stop, this is an vscode issue: https://github.com/microsoft/vscode/issues/43270\#issuecomment-430624161

**before the fix:**

![snippet-selection-before](https://user-images.githubusercontent.com/60742964/77517349-a4551800-6e84-11ea-9762-dfbdb96aee11.gif)

**after the fix:**

![snippet-selection-after](https://user-images.githubusercontent.com/60742964/77517417-c058b980-6e84-11ea-9651-9114dc1cf86f.gif)


