### PR TITLE
Add ia32 to 32-bit-compatible architectures

### DIFF
--- a/src/TabNine.ts
+++ b/src/TabNine.ts
@@ -136,7 +136,7 @@ export class TabNine {
 
   private static getBinaryPath(root): string {
     let arch;
-    if (process.arch == 'x32') {
+    if (process.arch == 'x32' || process.arch == 'ia32') {
       arch = 'i686'
     } else if (process.arch == 'x64') {
       arch = 'x86_64'


### PR DESCRIPTION
VS Code's 32-bit build on Windows is built against ia32, not x32. Therefore, prior to this change, TabNine unconditionally and silently failed to work on 32-bit VS Code.