### PR TITLE
upon alpha install, store the installed version in globalState and …

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -31,6 +31,7 @@ export const OPEN_LP_FROM_STATUS_BAR = "tabnine:open_lp";
 export const INSTALL_COMMAND = "workbench.extensions.installExtension";
 export const LATEST_RELEASE_URL = "https://api.github.com/repos/codota/tabnine-vscode/releases";
 export const MINIMAL_SUPPORTED_VSCODE_API = "1.35.0";
+export const ALPHA_VERSION_KEY = "tabnine.alpha.version";
 
 export const BRAND_NAME = "tabnine";
 export const DEFAULT_DETAIL = BRAND_NAME;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ async function backgroundInit(context: vscode.ExtensionContext) {
   await fetchCapabilitiesOnFocus();
 
   if (isCapabilityEnabled(Capability.ALPHA_CAPABILITY)) {
-    void handleAlpha();
+    void handleAlpha(context);
     pollNotifications(context);
     pollStatuses(context);
   }

--- a/src/test/suite/alphaInstaller.test.ts
+++ b/src/test/suite/alphaInstaller.test.ts
@@ -34,17 +34,20 @@ suite("Should update alpha release", () => {
     })
 
     test("in case of newer alpha version and current GA should update", async () => {
-        await runInstallation("3.0.11", "v3.1.11-alpha");
-        assertSuccessfulInstalled();
+        const expectedVersion = "v3.1.11-alpha";
+        await runInstallation("3.0.11", expectedVersion);
+        assertSuccessfulInstalled(expectedVersion);
     })
     test("in case of same version and alpha version and current GA should update", async () => {
-        await runInstallation("3.1.11", "v3.1.11-alpha.1234");
-        assertSuccessfulInstalled();
+        const expectedVersion = "v3.1.11-alpha.1234";
+        await runInstallation("3.1.11", expectedVersion);
+        assertSuccessfulInstalled(expectedVersion);
     })
 
     test("in case of newer alpha version, install the new one", async () => {
-        await runInstallation("3.1.10-alpha.150", "v3.1.10-alpha.280345345");
-        assertSuccessfulInstalled();
+        const expectedVersion = "v3.1.10-alpha.280345345";
+        await runInstallation("3.1.10-alpha.150", expectedVersion);
+        assertSuccessfulInstalled(expectedVersion);
     })
 })
 


### PR DESCRIPTION
…check the updates against it. this was added because vscode manages the version only in package.json and does not override it with the vsix name. so when installing ex-123.vsix with package version 3 vscode will install it as  ex-1