### PR TITLE
imporve empty line completions experience

### DIFF
--- a/src/capabilities/capabilities.ts
+++ b/src/capabilities/capabilities.ts
@@ -16,6 +16,7 @@ export enum Capability {
   INLINE_SUGGESTIONS = "inline_suggestions_mode",
   SNIPPET_SUGGESTIONS = "snippet_suggestions",
   LEFT_TREE_VIEW = "vscode.left_tree_view",
+  EMPTY_LINE_SUGGESTIONS = "empty_line_suggestions",
 }
 
 const enabledCapabilities: Record<string, boolean> = {};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,3 @@
-import { EOL } from "os";
 import * as vscode from "vscode";
 import handlePreReleaseChannels from "./preRelease/installer";
 import pollDownloadProgress from "./binary/pollDownloadProgress";
@@ -13,7 +12,7 @@ import {
   isCapabilityEnabled,
 } from "./capabilities/capabilities";
 import { registerCommands } from "./commandsHandler";
-import { COMPLETION_TRIGGERS, INSTRUMENTATION_KEY } from "./globals/consts";
+import { completionTriggers, INSTRUMENTATION_KEY } from "./globals/consts";
 import tabnineExtensionProperties from "./globals/tabnineExtensionProperties";
 import handleUninstall from "./handleUninstall";
 import { provideHover } from "./hovers/hoverHandler";
@@ -47,7 +46,6 @@ import getSuggestionMode, {
 import isGitpod from "./gitpod/isGitpod";
 import setupGitpodState from "./gitpod/setupGitpodState";
 import registerTreeView from "./treeView/registerTreeView";
-import runCompletion from "./runCompletion";
 
 export async function activate(
   context: vscode.ExtensionContext
@@ -108,39 +106,20 @@ async function backgroundInit(context: vscode.ExtensionContext) {
   await registerInlineHandlers(context);
 
   if (isAutoCompleteEnabled(context)) {
-    registerNewlinesListener();
     vscode.languages.registerCompletionItemProvider(
       { pattern: "**" },
       {
         provideCompletionItems,
       },
-      ...COMPLETION_TRIGGERS
+      ...completionTriggers(
+        isCapabilityEnabled(Capability.EMPTY_LINE_SUGGESTIONS)
+      )
     );
   }
   vscode.languages.registerHoverProvider(
     { pattern: "**" },
     {
       provideHover,
-    }
-  );
-}
-
-function registerNewlinesListener() {
-  vscode.workspace.onDidChangeTextDocument(
-    ({ document, contentChanges }: vscode.TextDocumentChangeEvent): void => {
-      const [change] = contentChanges;
-      if (
-        change?.text &&
-        change.text.includes(EOL) &&
-        change.text.trim() === ""
-      ) {
-        const lines = change.text.split(EOL);
-        const position = change.range.start.translate(
-          lines.length - 1,
-          -change.range.start.character + lines[lines.length - 1].length
-        );
-        void runCompletion(document, position);
-      }
     }
   );
 }

--- a/src/globals/consts.ts
+++ b/src/globals/consts.ts
@@ -60,7 +60,7 @@ export const BETA_CHANNEL_MESSAGE_SHOWN_KEY =
 export const DEFAULT_DETAIL = BRAND_NAME;
 export const PROGRESS_KEY = "tabnine.hide.progress";
 
-export const COMPLETION_TRIGGERS = [
+const COMPLETION_TRIGGERS = [
   " ",
   ".",
   "(",
@@ -90,6 +90,16 @@ export const COMPLETION_TRIGGERS = [
   "@",
   "!",
 ];
+
+export function completionTriggers(
+  isEmptyLineCapabilityEnabled: boolean
+): string[] {
+  const triggers = COMPLETION_TRIGGERS;
+  if (isEmptyLineCapabilityEnabled) {
+    triggers.push("\n");
+  }
+  return triggers;
+}
 
 export enum StateType {
   ERROR = "error",

--- a/src/provideCompletionItems.ts
+++ b/src/provideCompletionItems.ts
@@ -17,6 +17,7 @@ import { setCompletionStatus } from "./statusBar/statusBar";
 import { escapeTabStopSign, sleep } from "./utils/utils";
 
 const INCOMPLETE = true;
+const EMPTY_LINE_WARMUP_MILLIS = 110;
 
 export default async function provideCompletionItems(
   document: vscode.TextDocument,
@@ -37,9 +38,9 @@ async function completionsListFor(
       return [];
     }
 
-    if (document.lineAt(position.line).text.trim() === "") {
+    if (isEmptyLine(document, position)) {
       await runCompletion(document, position);
-      await sleep(110);
+      await sleep(EMPTY_LINE_WARMUP_MILLIS);
     }
 
     const response = await runCompletion(document, position);
@@ -72,6 +73,13 @@ async function completionsListFor(
 
     return [];
   }
+}
+
+function isEmptyLine(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): boolean {
+  return document.lineAt(position.line).text.trim() === "";
 }
 
 function extractDetailMessage(response: AutocompleteResult) {

--- a/src/provideCompletionItems.ts
+++ b/src/provideCompletionItems.ts
@@ -14,7 +14,7 @@ import tabnineExtensionProperties from "./globals/tabnineExtensionProperties";
 import runCompletion from "./runCompletion";
 import { COMPLETION_IMPORTS } from "./selectionHandler";
 import { setCompletionStatus } from "./statusBar/statusBar";
-import { escapeTabStopSign } from "./utils/utils";
+import { escapeTabStopSign, sleep } from "./utils/utils";
 
 const INCOMPLETE = true;
 
@@ -35,6 +35,11 @@ async function completionsListFor(
   try {
     if (!completionIsAllowed(document, position)) {
       return [];
+    }
+
+    if (document.lineAt(position.line).text.trim() === "") {
+      await runCompletion(document, position);
+      await sleep(110);
     }
 
     const response = await runCompletion(document, position);


### PR DESCRIPTION
if the user chooses to allow empty line completions (will be added in the hub soon) - trigger vscode's completion popup upon `\n` 