### PR TITLE
improve snippets behaviour

### DIFF
--- a/src/inlineSuggestions/registerHandlers.ts
+++ b/src/inlineSuggestions/registerHandlers.ts
@@ -25,6 +25,7 @@ import clearInlineSuggestionsState from "./clearDecoration";
 import { getNextSuggestion, getPrevSuggestion } from "./inlineSuggestionState";
 import setInlineSuggestion from "./setInlineSuggestion";
 import snippetAutoTriggerHandler from "./snippets/autoTriggerHandler";
+import { isInSnippetInsertion } from "./snippets/snippetDecoration";
 import requestSnippet from "./snippets/snippetProvider";
 import textListener from "./textListener";
 
@@ -75,7 +76,7 @@ export default async function registerInlineHandlers(
 function registerCursorChangeHandler() {
   window.onDidChangeTextEditorSelection((e: TextEditorSelectionChangeEvent) => {
     if (
-      e.kind !== undefined &&
+      !isInSnippetInsertion() &&
       e.kind !== TextEditorSelectionChangeKind.Command
     ) {
       void clearInlineSuggestionsState();

--- a/src/inlineSuggestions/snippets/snippetProvider.ts
+++ b/src/inlineSuggestions/snippets/snippetProvider.ts
@@ -1,4 +1,4 @@
-import { Position, TextDocument } from "vscode";
+import { Position, TextDocument, window } from "vscode";
 import {
   getCurrentSuggestion,
   setSuggestionsState,
@@ -18,6 +18,12 @@ export default async function requestSnippet(
     "snippet",
     trigger
   );
+
+  const currentUri = window.activeTextEditor?.document.uri;
+  if (currentUri !== document.uri) {
+    return;
+  }
+
   await setSuggestionsState(autocompleteResult);
   const currentSuggestion = getCurrentSuggestion();
   if (currentSuggestion) {


### PR DESCRIPTION
# Problems
1. Snippets are not deleted upon backspace
2. If you request a snippet in file a and then switch to file b - the snippet are appearing in the new location (file b). It happens because snippets are taking long to retrieve (1-2 sec).
Note: We do have a listener that clears the state upon cursor move, but its not triggered if you switch between files w/o moving the cursor.

# Solutions
1.  in `src/inlineSuggestions/registerHandlers.ts` - `e.kind === undefined` is true when the change is backspace, so not ignoring it and clearing the state in such cases. Its also true when the snippet blank space is being inserted, hence the `!isInSnippetInsertion()` check.
2. in `src/inlineSuggestions/snippets/snippetProvider.ts` - after retrieving snippet completions, check if the current file matches the file in which the request was fired.