### PR TITLE
feature: empty lines -> inline completions

### DIFF
--- a/src/capabilities/capabilities.ts
+++ b/src/capabilities/capabilities.ts
@@ -15,6 +15,7 @@ export enum Capability {
   SHOW_AGRESSIVE_STATUS_BAR_UNTIL_CLICKED = "promoteHub1",
   INLINE_SUGGESTIONS = "inline_suggestions_mode",
   SNIPPET_SUGGESTIONS = "snippet_suggestions",
+  SNIPPET_AUTO_TRIGGER = "snippet_auto_trigger",
   LEFT_TREE_VIEW = "vscode.left_tree_view",
   EMPTY_LINE_SUGGESTIONS = "empty_line_suggestions",
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import {
   isCapabilityEnabled,
 } from "./capabilities/capabilities";
 import { registerCommands } from "./commandsHandler";
-import { completionTriggers, INSTRUMENTATION_KEY } from "./globals/consts";
+import { COMPLETION_TRIGGERS, INSTRUMENTATION_KEY } from "./globals/consts";
 import tabnineExtensionProperties from "./globals/tabnineExtensionProperties";
 import handleUninstall from "./handleUninstall";
 import { provideHover } from "./hovers/hoverHandler";
@@ -115,9 +115,7 @@ async function backgroundInit(context: vscode.ExtensionContext) {
       {
         provideCompletionItems,
       },
-      ...completionTriggers(
-        isCapabilityEnabled(Capability.EMPTY_LINE_SUGGESTIONS)
-      )
+      ...COMPLETION_TRIGGERS
     );
   }
   vscode.languages.registerHoverProvider(

--- a/src/globals/consts.ts
+++ b/src/globals/consts.ts
@@ -60,7 +60,7 @@ export const BETA_CHANNEL_MESSAGE_SHOWN_KEY =
 export const DEFAULT_DETAIL = BRAND_NAME;
 export const PROGRESS_KEY = "tabnine.hide.progress";
 
-const COMPLETION_TRIGGERS = [
+export const COMPLETION_TRIGGERS = [
   " ",
   ".",
   "(",
@@ -90,16 +90,6 @@ const COMPLETION_TRIGGERS = [
   "@",
   "!",
 ];
-
-export function completionTriggers(
-  isEmptyLineCapabilityEnabled: boolean
-): string[] {
-  const triggers = COMPLETION_TRIGGERS;
-  if (isEmptyLineCapabilityEnabled) {
-    triggers.push("\n");
-  }
-  return triggers;
-}
 
 export enum StateType {
   ERROR = "error",

--- a/src/inlineSuggestions/inlineSuggestionState.ts
+++ b/src/inlineSuggestions/inlineSuggestionState.ts
@@ -1,15 +1,19 @@
 import { commands } from "vscode";
 import { AutocompleteResult, ResultEntry } from "../binary/requests/requests";
+import { CompletionType } from "../runCompletion";
 import { rotate } from "../utils/rotate";
 
 let autocompleteResult: AutocompleteResult | undefined | null;
-
+let stateCompletionType: CompletionType | undefined | null;
 let iterator = rotate(0);
 
 export async function setSuggestionsState(
-  autocompleteResults: AutocompleteResult | undefined | null
+  autocompleteResults: AutocompleteResult | undefined | null,
+  completionType?: CompletionType
 ): Promise<void> {
   autocompleteResult = autocompleteResults;
+  stateCompletionType = completionType || "normal";
+
   if (autocompleteResult?.results?.length) {
     iterator = rotate(autocompleteResult.results.length - 1);
     await toggleInlineState(true);
@@ -21,6 +25,8 @@ export async function setSuggestionsState(
 export async function clearState(): Promise<void> {
   autocompleteResult = null;
   iterator = rotate(0);
+  stateCompletionType = null;
+
   await toggleInlineState(false);
 }
 async function toggleInlineState(withinSuggestion: boolean): Promise<void> {
@@ -29,6 +35,10 @@ async function toggleInlineState(withinSuggestion: boolean): Promise<void> {
     "tabnine.in-inline-suggestions",
     withinSuggestion
   );
+}
+
+export function getStateCompletionType(): CompletionType | undefined | null {
+  return stateCompletionType;
 }
 
 export function getNextSuggestion(): ResultEntry | undefined {

--- a/src/inlineSuggestions/positionExtracter.ts
+++ b/src/inlineSuggestions/positionExtracter.ts
@@ -46,7 +46,7 @@ export function isOnlyWhitespaces(text: string): boolean {
 
 export function isEmptyLinesWithNewlineAutoInsert(
   change: TextDocumentContentChangeEvent
-) {
+): boolean {
   return getLines(change.text).length > 2 && isOnlyWhitespaces(change.text);
 }
 

--- a/src/inlineSuggestions/positionExtracter.ts
+++ b/src/inlineSuggestions/positionExtracter.ts
@@ -1,0 +1,45 @@
+import { EOL } from "os";
+import { Position, TextDocumentContentChangeEvent } from "vscode";
+
+export default function getCurrentPosition(
+  change: TextDocumentContentChangeEvent
+): Position {
+  const {
+    linesDelta,
+    characterDelta,
+    lastLineLength,
+  } = calculateChangeDimensions(change);
+
+  return change.range.start.translate(
+    linesDelta,
+    linesDelta === 0
+      ? characterDelta
+      : -change.range.start.character + lastLineLength
+  );
+}
+
+function calculateChangeDimensions(
+  change: TextDocumentContentChangeEvent
+): {
+  linesDelta: number;
+  characterDelta: number;
+  lastLineLength: number;
+} {
+  const lines = getLines(change.text);
+  let linesDelta = lines.length - 1;
+  // handle auto inserting of newlines, for example when the closing bracket
+  // of a function is being inserted automatically by vscode.
+  if (lines.length > 2) linesDelta -= 1;
+  const characterDelta = change.text.length;
+  const lastLineLength = lines[linesDelta].length;
+
+  return {
+    linesDelta,
+    characterDelta,
+    lastLineLength,
+  };
+}
+
+function getLines(text: string) {
+  return text.split(EOL);
+}

--- a/src/inlineSuggestions/positionExtracter.ts
+++ b/src/inlineSuggestions/positionExtracter.ts
@@ -29,7 +29,7 @@ function calculateChangeDimensions(
   let linesDelta = lines.length - 1;
   // handle auto inserting of newlines, for example when the closing bracket
   // of a function is being inserted automatically by vscode.
-  if (lines.length > 2) linesDelta -= 1;
+  if (isEmptyLinesWithNewlineAutoInsert(change)) linesDelta -= 1;
   const characterDelta = change.text.length;
   const lastLineLength = lines[linesDelta].length;
 
@@ -38,6 +38,16 @@ function calculateChangeDimensions(
     characterDelta,
     lastLineLength,
   };
+}
+
+export function isOnlyWhitespaces(text: string): boolean {
+  return text.trim() === "";
+}
+
+export function isEmptyLinesWithNewlineAutoInsert(
+  change: TextDocumentContentChangeEvent
+) {
+  return getLines(change.text).length > 2 && isOnlyWhitespaces(change.text);
 }
 
 function getLines(text: string) {

--- a/src/inlineSuggestions/registerHandlers.ts
+++ b/src/inlineSuggestions/registerHandlers.ts
@@ -23,7 +23,9 @@ import {
 import acceptInlineSuggestion from "./acceptInlineSuggestion";
 import clearInlineSuggestionsState from "./clearDecoration";
 import { getNextSuggestion, getPrevSuggestion } from "./inlineSuggestionState";
-import setInlineSuggestion from "./setInlineSuggestion";
+import setInlineSuggestion, {
+  isShowingDecoration,
+} from "./setInlineSuggestion";
 import snippetAutoTriggerHandler from "./snippets/autoTriggerHandler";
 import { isInSnippetInsertion } from "./snippets/snippetDecoration";
 import requestSnippet from "./snippets/snippetProvider";
@@ -84,8 +86,13 @@ export default async function registerInlineHandlers(
 
 function registerCursorChangeHandler() {
   window.onDidChangeTextEditorSelection((e: TextEditorSelectionChangeEvent) => {
+    const inSnippetInsertion = isInSnippetInsertion();
+    const showingDecoration = isShowingDecoration();
+    const inTheMiddleOfConstructingSnippet =
+      inSnippetInsertion && !showingDecoration;
+
     if (
-      !isInSnippetInsertion() &&
+      !inTheMiddleOfConstructingSnippet &&
       e.kind !== TextEditorSelectionChangeKind.Command
     ) {
       void clearInlineSuggestionsState();

--- a/src/inlineSuggestions/registerHandlers.ts
+++ b/src/inlineSuggestions/registerHandlers.ts
@@ -45,11 +45,16 @@ function isSnippetSuggestionsEnabled(context: ExtensionContext) {
   );
 }
 
+function isSnippetAutoTriggerEnabled() {
+  return isCapabilityEnabled(Capability.SNIPPET_AUTO_TRIGGER);
+}
+
 export default async function registerInlineHandlers(
   context: ExtensionContext
 ): Promise<void> {
   const inlineEnabled = isInlineEnabled(context);
   const snippetsEnabled = isSnippetSuggestionsEnabled(context);
+
   if (!inlineEnabled && !snippetsEnabled) return;
 
   if (inlineEnabled) {
@@ -59,7 +64,11 @@ export default async function registerInlineHandlers(
 
   if (snippetsEnabled) {
     await enableSnippetSuggestionsContext();
-    registerSnippetAutoTriggerHandler();
+
+    if (isSnippetAutoTriggerEnabled()) {
+      registerSnippetAutoTriggerHandler();
+    }
+
     context.subscriptions.push(registerSnippetHandler());
   }
 

--- a/src/inlineSuggestions/setInlineSuggestion.ts
+++ b/src/inlineSuggestions/setInlineSuggestion.ts
@@ -19,7 +19,7 @@ import {
 } from "./snippets/snippetDecoration";
 
 const inlineDecorationType = window.createTextEditorDecorationType({});
-let showingDecoration: boolean = false;
+let showingDecoration = false;
 
 export default function setInlineSuggestion(
   document: TextDocument,

--- a/src/inlineSuggestions/setInlineSuggestion.ts
+++ b/src/inlineSuggestions/setInlineSuggestion.ts
@@ -6,9 +6,13 @@ import {
   window,
 } from "vscode";
 import { ResultEntry } from "../binary/requests/requests";
-import { clearState, getCurrentPrefix } from "./inlineSuggestionState";
+import {
+  clearState,
+  getCurrentPrefix,
+  getStateCompletionType,
+} from "./inlineSuggestionState";
 import hoverPopup from "./hoverPopup";
-import { isMultiline, trimEnd } from "../utils/utils";
+import { trimEnd } from "../utils/utils";
 import {
   getSnippetDecorations,
   handleClearSnippetDecoration,
@@ -95,9 +99,11 @@ async function showInlineDecoration(
   position: Position,
   suggestion: string
 ): Promise<void> {
-  const decorations = isMultiline(suggestion)
-    ? await getSnippetDecorations(position, suggestion)
-    : getOneLineDecorations(suggestion, position);
+  const currentCompletionType = getStateCompletionType();
+  const decorations =
+    currentCompletionType === "snippet"
+      ? await getSnippetDecorations(position, suggestion)
+      : getOneLineDecorations(suggestion, position);
 
   window.activeTextEditor?.setDecorations(inlineDecorationType, decorations);
 }

--- a/src/inlineSuggestions/setInlineSuggestion.ts
+++ b/src/inlineSuggestions/setInlineSuggestion.ts
@@ -19,6 +19,7 @@ import {
 } from "./snippets/snippetDecoration";
 
 const inlineDecorationType = window.createTextEditorDecorationType({});
+let showingDecoration: boolean = false;
 
 export default function setInlineSuggestion(
   document: TextDocument,
@@ -106,6 +107,7 @@ async function showInlineDecoration(
       : getOneLineDecorations(suggestion, position);
 
   window.activeTextEditor?.setDecorations(inlineDecorationType, decorations);
+  showingDecoration = true;
 }
 
 function getOneLineDecorations(
@@ -137,4 +139,9 @@ function getOneLineDecorations(
 export function clearInlineDecoration(): void {
   handleClearSnippetDecoration();
   window.activeTextEditor?.setDecorations(inlineDecorationType, []);
+  showingDecoration = false;
+}
+
+export function isShowingDecoration(): boolean {
+  return showingDecoration;
 }

--- a/src/inlineSuggestions/snippets/autoTriggerHandler.ts
+++ b/src/inlineSuggestions/snippets/autoTriggerHandler.ts
@@ -1,10 +1,7 @@
 import { EOL } from "os";
-import {
-  Position,
-  TextDocumentChangeEvent,
-  TextDocumentContentChangeEvent,
-} from "vscode";
+import { TextDocumentChangeEvent } from "vscode";
 import { SnippetRequestTrigger } from "../../binary/requests/requests";
+import getCurrentPosition from "../positionExtracter";
 import { isInSnippetInsertion } from "./snippetDecoration";
 import requestSnippet from "./snippetProvider";
 
@@ -20,15 +17,4 @@ export default async function snippetAutoTriggerHandler({
   if (!isInSnippetInsertion() && hasNewlines && currentLineIsEmpty) {
     await requestSnippet(document, position, SnippetRequestTrigger.Auto);
   }
-}
-
-function getCurrentPosition(change: TextDocumentContentChangeEvent): Position {
-  const lines = change.text.split(EOL);
-  const lastLineLengthTranslation =
-    -change.range.start.character + lines[lines.length - 1].length;
-
-  return change.range.start.translate(
-    lines.length - 1,
-    lastLineLengthTranslation
-  );
 }

--- a/src/inlineSuggestions/snippets/snippetProvider.ts
+++ b/src/inlineSuggestions/snippets/snippetProvider.ts
@@ -24,7 +24,7 @@ export default async function requestSnippet(
     return;
   }
 
-  await setSuggestionsState(autocompleteResult);
+  await setSuggestionsState(autocompleteResult, "snippet");
   const currentSuggestion = getCurrentSuggestion();
   if (currentSuggestion) {
     setInlineSuggestion(document, position, currentSuggestion);

--- a/src/inlineSuggestions/textListener.ts
+++ b/src/inlineSuggestions/textListener.ts
@@ -1,9 +1,7 @@
 import {
-  Position,
   TextDocumentChangeEvent,
   TextDocumentContentChangeEvent,
 } from "vscode";
-import { EOL } from "os";
 import {
   getCurrentSuggestion,
   setSuggestionsState,
@@ -13,19 +11,35 @@ import setInlineSuggestion from "./setInlineSuggestion";
 import clearInlineSuggestionsState from "./clearDecoration";
 import { isInSnippetInsertion } from "./snippets/snippetDecoration";
 import { URI_SCHEME_FILE } from "../globals/consts";
+import { sleep } from "../utils/utils";
+import { Capability, isCapabilityEnabled } from "../capabilities/capabilities";
+import getCurrentPosition from "./positionExtracter";
+
+const EMPTY_LINE_WARMUP_MILLIS = 110;
 
 export default async function textListener({
   document,
   contentChanges,
 }: TextDocumentChangeEvent): Promise<void> {
   const [change] = contentChanges;
+  const currentTextPosition = getCurrentPosition(change);
+
+  const emptyLinesEnabled = isCapabilityEnabled(
+    Capability.EMPTY_LINE_SUGGESTIONS
+  );
+  const shouldHandleEmptyLine =
+    emptyLinesEnabled && isEmptyLine(change) && !isInSnippetInsertion();
+
+  if (shouldHandleEmptyLine) {
+    await runCompletion(document, currentTextPosition);
+    await sleep(EMPTY_LINE_WARMUP_MILLIS);
+    await runCompletion(document, currentTextPosition);
+  }
 
   if (
-    isSingleTypingChange(contentChanges, change) &&
+    (shouldHandleEmptyLine || isSingleTypingChange(contentChanges, change)) &&
     document.uri.scheme === URI_SCHEME_FILE
   ) {
-    const currentTextPosition = getCurrentPosition(change);
-
     const autocompleteResult = await runCompletion(
       document,
       currentTextPosition
@@ -43,6 +57,10 @@ export default async function textListener({
   }
 }
 
+function isEmptyLine(change: TextDocumentContentChangeEvent): boolean {
+  return change.text.trim() === "";
+}
+
 export function isSingleTypingChange(
   contentChanges: readonly TextDocumentContentChangeEvent[],
   change: TextDocumentContentChangeEvent
@@ -50,14 +68,4 @@ export function isSingleTypingChange(
   const isSingleSelectionChange = contentChanges.length === 1;
   const isSingleCharacterChange = change.text.length === 1;
   return isSingleSelectionChange && isSingleCharacterChange;
-}
-
-function getCurrentPosition(change: TextDocumentContentChangeEvent): Position {
-  const lineDelta = getLinesCount(change.text);
-  const characterDelta = change.text.length;
-  return change.range.start.translate(lineDelta, characterDelta);
-}
-
-function getLinesCount(text: string) {
-  return text.split(EOL).length - 1;
 }

--- a/src/provideCompletionItems.ts
+++ b/src/provideCompletionItems.ts
@@ -14,10 +14,9 @@ import tabnineExtensionProperties from "./globals/tabnineExtensionProperties";
 import runCompletion from "./runCompletion";
 import { COMPLETION_IMPORTS } from "./selectionHandler";
 import { setCompletionStatus } from "./statusBar/statusBar";
-import { escapeTabStopSign, sleep } from "./utils/utils";
+import { escapeTabStopSign } from "./utils/utils";
 
 const INCOMPLETE = true;
-const EMPTY_LINE_WARMUP_MILLIS = 110;
 
 export default async function provideCompletionItems(
   document: vscode.TextDocument,
@@ -36,11 +35,6 @@ async function completionsListFor(
   try {
     if (!completionIsAllowed(document, position)) {
       return [];
-    }
-
-    if (isEmptyLine(document, position)) {
-      await runCompletion(document, position);
-      await sleep(EMPTY_LINE_WARMUP_MILLIS);
     }
 
     const response = await runCompletion(document, position);
@@ -73,13 +67,6 @@ async function completionsListFor(
 
     return [];
   }
-}
-
-function isEmptyLine(
-  document: vscode.TextDocument,
-  position: vscode.Position
-): boolean {
-  return document.lineAt(position.line).text.trim() === "";
 }
 
 function extractDetailMessage(response: AutocompleteResult) {


### PR DESCRIPTION
### What's been done
If `EMPTY_LINE_SUGGESTIONS` capability is enabled, provide inline suggestions on empty lines

### Technical aspect
1. Move empty lines logic from `provideCompletionIterms.ts` (popup completions) to `textListener.ts` (inline completions)
2. Add `CompletionType` to `inlineSuggestionState.ts` to differentiate between snippet completions and inline completions - previously was done by checking if the completion contains more than one line, which is a weaker way to get this information.
3. extract `getCurrentPosition` to a new file, allowing both snippet and regular completions to use the same function to determine a `Position` from `TextDocumentContentChangeEvent`. While I was playing around with the logic of this function to support empty lines, it came out as just what was needed to unify snippets and regular completions so I just merged them.