### PR TITLE
fix snippet clear hint bad behaviour

### DIFF
--- a/src/inlineSuggestions/snippets/snippetDecoration.ts
+++ b/src/inlineSuggestions/snippets/snippetDecoration.ts
@@ -84,9 +84,28 @@ async function insertBlankSnippet(
 
 export function handleClearSnippetDecoration(): void {
   if (snippetBlankRange) {
+    const fixedRange = calculateStartAfterUserInput(snippetBlankRange);
+
+    if (fixedRange) snippetBlankRange = fixedRange;
+
     void window.activeTextEditor?.edit((editBuilder) => {
       editBuilder.delete(snippetBlankRange as Range);
     });
     snippetBlankRange = undefined;
   }
+}
+
+function calculateStartAfterUserInput(range: Range): Range | undefined {
+  const currentPosition = window.activeTextEditor?.selection.active;
+
+  if (currentPosition) {
+    const linesDiff = currentPosition.line - range.start.line;
+    const charsDiff = currentPosition.character - range.start.character;
+    return new Range(
+      range.start.translate(linesDiff, charsDiff),
+      range.end.translate(linesDiff)
+    );
+  }
+
+  return undefined;
 }

--- a/src/inlineSuggestions/snippets/snippetDecoration.ts
+++ b/src/inlineSuggestions/snippets/snippetDecoration.ts
@@ -86,10 +86,8 @@ export function handleClearSnippetDecoration(): void {
   if (snippetBlankRange) {
     const fixedRange = calculateStartAfterUserInput(snippetBlankRange);
 
-    if (fixedRange) snippetBlankRange = fixedRange;
-
     void window.activeTextEditor?.edit((editBuilder) => {
-      editBuilder.delete(snippetBlankRange as Range);
+      editBuilder.delete((fixedRange || snippetBlankRange) as Range);
     });
     snippetBlankRange = undefined;
   }


### PR DESCRIPTION
# Problem
Currently, when a snippet hint is displayed and the user types something, it gets deleted along with the snippet hint's disappearance. It happens because we delete the `snippetBlankRange` which starts where the user requested a snippet, and not where they are now (when deleting the hint)

# Solution
When deleting the hint, calculate the difference between the position in which the user requested a snippet and the position in which they are now. Delete the only difference between the original `snippetBlankRange` and the new position.

https://user-images.githubusercontent.com/67855609/141697300-7a55b0b7-34bf-4b7e-97ab-379f652db0a0.mp4

