### PR TITLE
snippets improvements

### DIFF
--- a/src/binary/requests/requests.ts
+++ b/src/binary/requests/requests.ts
@@ -16,6 +16,7 @@ export type MarkdownStringSpec = {
 export enum CompletionKind {
   Classic = "Classic",
   Line = "Line",
+  Snippet = "Snippet",
 }
 
 export type ResultEntry = {

--- a/src/inlineSuggestions/inlineSuggestionState.ts
+++ b/src/inlineSuggestions/inlineSuggestionState.ts
@@ -1,6 +1,5 @@
 import { commands } from "vscode";
 import { AutocompleteResult, ResultEntry } from "../binary/requests/requests";
-import { CompletionType } from "../runCompletion";
 import { rotate } from "../utils/rotate";
 
 let autocompleteResult: AutocompleteResult | undefined | null;
@@ -8,7 +7,6 @@ let iterator = rotate(0);
 
 export async function setSuggestionsState(
   autocompleteResults: AutocompleteResult | undefined | null,
-  completionType?: CompletionType
 ): Promise<void> {
   autocompleteResult = autocompleteResults;
 

--- a/src/inlineSuggestions/inlineSuggestionState.ts
+++ b/src/inlineSuggestions/inlineSuggestionState.ts
@@ -6,7 +6,7 @@ let autocompleteResult: AutocompleteResult | undefined | null;
 let iterator = rotate(0);
 
 export async function setSuggestionsState(
-  autocompleteResults: AutocompleteResult | undefined | null,
+  autocompleteResults: AutocompleteResult | undefined | null
 ): Promise<void> {
   autocompleteResult = autocompleteResults;
 

--- a/src/inlineSuggestions/inlineSuggestionState.ts
+++ b/src/inlineSuggestions/inlineSuggestionState.ts
@@ -4,7 +4,6 @@ import { CompletionType } from "../runCompletion";
 import { rotate } from "../utils/rotate";
 
 let autocompleteResult: AutocompleteResult | undefined | null;
-let stateCompletionType: CompletionType | undefined | null;
 let iterator = rotate(0);
 
 export async function setSuggestionsState(
@@ -12,7 +11,6 @@ export async function setSuggestionsState(
   completionType?: CompletionType
 ): Promise<void> {
   autocompleteResult = autocompleteResults;
-  stateCompletionType = completionType || "normal";
 
   if (autocompleteResult?.results?.length) {
     iterator = rotate(autocompleteResult.results.length - 1);
@@ -25,7 +23,6 @@ export async function setSuggestionsState(
 export async function clearState(): Promise<void> {
   autocompleteResult = null;
   iterator = rotate(0);
-  stateCompletionType = null;
 
   await toggleInlineState(false);
 }
@@ -37,10 +34,6 @@ async function toggleInlineState(withinSuggestion: boolean): Promise<void> {
   );
 }
 
-export function getStateCompletionType(): CompletionType | undefined | null {
-  return stateCompletionType;
-}
-
 export function getNextSuggestion(): ResultEntry | undefined {
   return results()?.[iterator.next()];
 }
@@ -48,6 +41,7 @@ export function getNextSuggestion(): ResultEntry | undefined {
 export function getPrevSuggestion(): ResultEntry | undefined {
   return results()?.[iterator.prev()];
 }
+
 export function getCurrentSuggestion(): ResultEntry | undefined {
   return results()?.[iterator.current()];
 }

--- a/src/inlineSuggestions/setInlineSuggestion.ts
+++ b/src/inlineSuggestions/setInlineSuggestion.ts
@@ -5,11 +5,11 @@ import {
   TextDocument,
   window,
 } from "vscode";
-import { ResultEntry } from "../binary/requests/requests";
+import { CompletionKind, ResultEntry } from "../binary/requests/requests";
 import {
   clearState,
   getCurrentPrefix,
-  getStateCompletionType,
+  getCurrentSuggestion,
 } from "./inlineSuggestionState";
 import hoverPopup from "./hoverPopup";
 import { trimEnd } from "../utils/utils";
@@ -100,9 +100,9 @@ async function showInlineDecoration(
   position: Position,
   suggestion: string
 ): Promise<void> {
-  const currentCompletionType = getStateCompletionType();
+  const currentCompletionKind = getCurrentSuggestion()?.completion_kind;
   const decorations =
-    currentCompletionType === "snippet"
+    currentCompletionKind === CompletionKind.Snippet
       ? await getSnippetDecorations(position, suggestion)
       : getOneLineDecorations(suggestion, position);
 

--- a/src/inlineSuggestions/snippets/snippetDecoration.ts
+++ b/src/inlineSuggestions/snippets/snippetDecoration.ts
@@ -98,8 +98,9 @@ function calculateStartAfterUserInput(range: Range): Range | undefined {
   const textInsideSnippetBlankRange = window.activeTextEditor?.document.getText(
     range
   );
+  const blankRangeContainsText = textInsideSnippetBlankRange?.trim() !== "";
 
-  if (currentPosition && textInsideSnippetBlankRange?.trim() !== "") {
+  if (currentPosition && blankRangeContainsText) {
     const linesDiff = currentPosition.line - range.start.line;
     const charsDiff = currentPosition.character - range.start.character;
     return new Range(

--- a/src/inlineSuggestions/snippets/snippetDecoration.ts
+++ b/src/inlineSuggestions/snippets/snippetDecoration.ts
@@ -95,8 +95,11 @@ export function handleClearSnippetDecoration(): void {
 
 function calculateStartAfterUserInput(range: Range): Range | undefined {
   const currentPosition = window.activeTextEditor?.selection.active;
+  const textInsideSnippetBlankRange = window.activeTextEditor?.document.getText(
+    range
+  );
 
-  if (currentPosition) {
+  if (currentPosition && textInsideSnippetBlankRange?.trim() !== "") {
     const linesDiff = currentPosition.line - range.start.line;
     const charsDiff = currentPosition.character - range.start.character;
     return new Range(

--- a/src/inlineSuggestions/snippets/snippetProvider.ts
+++ b/src/inlineSuggestions/snippets/snippetProvider.ts
@@ -24,7 +24,7 @@ export default async function requestSnippet(
     return;
   }
 
-  await setSuggestionsState(autocompleteResult, "snippet");
+  await setSuggestionsState(autocompleteResult);
   const currentSuggestion = getCurrentSuggestion();
   if (currentSuggestion) {
     setInlineSuggestion(document, position, currentSuggestion);

--- a/src/inlineSuggestions/textListener.ts
+++ b/src/inlineSuggestions/textListener.ts
@@ -58,9 +58,6 @@ export default async function textListener({
     }
     void clearInlineSuggestionsState();
   }
-  if (!isInSnippetInsertion()) {
-    void clearInlineSuggestionsState();
-  }
 }
 
 function isEmptyLine(


### PR DESCRIPTION
## Towards merging snippet completions with regular ones
We're trying to smoothly integrate snippets as part of your regular tabnine experience, which requires a lot of things (outside the scope of this pr).
### What's been done
- Use `CompletionKind` to determine whether the current inline hint is a snippet or a regular one - this allows to have a state with both types of completions and move between them smoothly
- Removed an old `if` statement in `src/inlineSuggestions/textListener.ts` that's turned out to be redundant:
The code was suppose to clear the inline hint in case the text has changed and you don't want to show a new hint. This is being handled by our cursor listener - a changed text also moves the cursor.
- Fix snippet hint deletion upon cursor move - in my previous fixes I caused a problem where if you move your cursor while a snippet hint is being displayed, it removes the same **range** that the snippet took, but **shifts** it to where your current cursor is.
For example, if you had:
```javascript
function foo() {
  // <- cursor here [snippet]
  // [snippet]
  // [snippet]
}
```
and you moved your cursor one line up, it'll delete the first line as well:
```javascript
// <- cursor here [deleted "function foo() {"]
// [deleted empty line]
// [deleted empty line]

}
```