### PR TITLE
feature: make snippets work on non empty lines

### DIFF
--- a/src/inlineSuggestions/clearDecoration.ts
+++ b/src/inlineSuggestions/clearDecoration.ts
@@ -2,6 +2,6 @@ import { clearState } from "./inlineSuggestionState";
 import { clearInlineDecoration } from "./setInlineSuggestion";
 
 export default async function clearInlineSuggestionsState(): Promise<void> {
-  clearInlineDecoration();
+  await clearInlineDecoration();
   await clearState();
 }

--- a/src/inlineSuggestions/registerHandlers.ts
+++ b/src/inlineSuggestions/registerHandlers.ts
@@ -27,7 +27,7 @@ import setInlineSuggestion, {
   isShowingDecoration,
 } from "./setInlineSuggestion";
 import snippetAutoTriggerHandler from "./snippets/autoTriggerHandler";
-import { isInSnippetInsertion } from "./snippets/snippetDecoration";
+import { isInSnippetInsertion } from "./snippets/blankSnippet";
 import requestSnippet from "./snippets/snippetProvider";
 import textListener from "./textListener";
 
@@ -122,7 +122,7 @@ function registerPrevHandler(): Disposable {
     ({ document, selection }: TextEditor) => {
       const prevSuggestion = getPrevSuggestion();
       if (prevSuggestion) {
-        setInlineSuggestion(document, selection.active, prevSuggestion);
+        void setInlineSuggestion(document, selection.active, prevSuggestion);
       }
     }
   );
@@ -134,7 +134,7 @@ function registerNextHandler(): Disposable {
     ({ document, selection }: TextEditor) => {
       const nextSuggestion = getNextSuggestion();
       if (nextSuggestion) {
-        setInlineSuggestion(document, selection.active, nextSuggestion);
+        void setInlineSuggestion(document, selection.active, nextSuggestion);
       }
     }
   );

--- a/src/inlineSuggestions/setInlineSuggestion.ts
+++ b/src/inlineSuggestions/setInlineSuggestion.ts
@@ -21,12 +21,12 @@ import {
 const inlineDecorationType = window.createTextEditorDecorationType({});
 let showingDecoration = false;
 
-export default function setInlineSuggestion(
+export default async function setInlineSuggestion(
   document: TextDocument,
   position: Position,
   newSuggestion: ResultEntry
-): void {
-  clearInlineDecoration();
+): Promise<void> {
+  await clearInlineDecoration();
   const prefix = getCurrentPrefix();
   if (
     shouldNotHandleThisSuggestion(prefix, newSuggestion, document, position)
@@ -136,9 +136,9 @@ function getOneLineDecorations(
   return decorations;
 }
 
-export function clearInlineDecoration(): void {
-  handleClearSnippetDecoration();
+export async function clearInlineDecoration(): Promise<void> {
   window.activeTextEditor?.setDecorations(inlineDecorationType, []);
+  await handleClearSnippetDecoration();
   showingDecoration = false;
 }
 

--- a/src/inlineSuggestions/snippets/acceptSnippetSuggestion.ts
+++ b/src/inlineSuggestions/snippets/acceptSnippetSuggestion.ts
@@ -18,10 +18,7 @@ export default async function acceptSnippet(
   allSuggestions: ResultEntry[]
 ): Promise<void> {
   const position = currentTextPosition.with(undefined, 0);
-  // "take 'abc'.length into consideration"
-  const indentation =
-    editor.selection.active.character -
-    editor.document.lineAt(position).text.trim().length;
+  const indentation = getCurrentIndentation(editor, position);
   const insertText = constructInsertSnippet(currentSuggestion, indentation);
 
   const completion: CompletionArguments = {
@@ -36,6 +33,14 @@ export default async function acceptSnippet(
   await editor.insertSnippet(insertText, range);
 
   void commands.executeCommand(COMPLETION_IMPORTS, completion);
+}
+
+// take 'abc'.length into consideration
+function getCurrentIndentation(editor: TextEditor, position: Position) {
+  return (
+    editor.selection.active.character -
+    editor.document.lineAt(position).text.trim().length
+  );
 }
 
 function constructInsertSnippet({ new_prefix }: ResultEntry, indent: number) {

--- a/src/inlineSuggestions/snippets/autoTriggerHandler.ts
+++ b/src/inlineSuggestions/snippets/autoTriggerHandler.ts
@@ -2,7 +2,7 @@ import { EOL } from "os";
 import { TextDocumentChangeEvent } from "vscode";
 import { SnippetRequestTrigger } from "../../binary/requests/requests";
 import getCurrentPosition from "../positionExtracter";
-import { isInSnippetInsertion } from "./snippetDecoration";
+import { isInSnippetInsertion } from "./blankSnippet";
 import requestSnippet from "./snippetProvider";
 
 export default async function snippetAutoTriggerHandler({

--- a/src/inlineSuggestions/snippets/blankSnippet.ts
+++ b/src/inlineSuggestions/snippets/blankSnippet.ts
@@ -28,7 +28,7 @@ export async function insertBlankSnippet(
   }
 }
 
-export async function insertBlankSnippetAtEmptyLine(
+async function insertBlankSnippetAtEmptyLine(
   lines: string[],
   position: Position
 ): Promise<void> {
@@ -46,7 +46,7 @@ export async function insertBlankSnippetAtEmptyLine(
   );
 }
 
-export async function insertBlankSnippetAtNonEmptyLine(
+async function insertBlankSnippetAtNonEmptyLine(
   lines: string[],
   position: Position
 ): Promise<void> {
@@ -87,25 +87,29 @@ export async function removeBlankSnippet(): Promise<void> {
       rangeToRemove.end
     ).text;
     const lastLineLength = lastLineText?.length;
-    await window.activeTextEditor
-      ?.edit((editBuilder) => {
-        editBuilder.delete(
-          new Range(
-            rangeToRemove.start,
-            rangeToRemove.end.translate(0, lastLineLength)
-          )
-        );
-      })
-      .then(() => {
-        snippetBlankRange = undefined;
-      });
+    await window.activeTextEditor?.edit((editBuilder) => {
+      editBuilder.delete(
+        new Range(
+          rangeToRemove.start,
+          rangeToRemove.end.translate(0, lastLineLength)
+        )
+      );
+    });
+
+    snippetBlankRange = undefined;
   }
 }
 
 function calculateStartAfterUserInput(range: Range): Range | undefined {
   const currentPosition = window.activeTextEditor?.selection.active;
+  const textInsideSnippetBlankRange = window.activeTextEditor?.document.getText(
+    range
+  );
+  // a space is considered a text too, so trimming all whitespaces yields the wrong result here.
+  const blankRangeContainsText =
+    textInsideSnippetBlankRange?.replace(new RegExp(EOL, "g"), "") !== "";
 
-  if (currentPosition) {
+  if (currentPosition && blankRangeContainsText) {
     const linesDiff = currentPosition.line - range.start.line;
     const charsDiff = currentPosition.character - range.start.character;
     return new Range(

--- a/src/inlineSuggestions/snippets/blankSnippet.ts
+++ b/src/inlineSuggestions/snippets/blankSnippet.ts
@@ -1,0 +1,115 @@
+import { EOL } from "os";
+import { commands, Position, Range, SnippetString, window } from "vscode";
+
+let snippetBlankRange: Range | undefined;
+
+export function isInSnippetInsertion(): boolean {
+  return !!snippetBlankRange;
+}
+
+// for tests only
+export function getSnippetBlankRange(): Range | undefined {
+  return snippetBlankRange;
+}
+
+export async function insertBlankSnippet(
+  lines: string[],
+  position: Position
+): Promise<void> {
+  snippetBlankRange = undefined;
+  const currentLineText = window.activeTextEditor?.document.lineAt(position)
+    .text;
+  const isCurrentLineEmpty = currentLineText?.trim().length === 0;
+
+  if (isCurrentLineEmpty) {
+    await insertBlankSnippetAtEmptyLine(lines, position);
+  } else {
+    await insertBlankSnippetAtNonEmptyLine(lines, position);
+  }
+}
+
+export async function insertBlankSnippetAtEmptyLine(
+  lines: string[],
+  position: Position
+): Promise<void> {
+  const snippet = new SnippetString(" ".repeat(position.character));
+  snippet.appendTabstop(0);
+  snippet.appendText(EOL.repeat(lines.length - 1));
+  snippetBlankRange = new Range(
+    position,
+    position.translate(lines.length - 1, -position.character)
+  );
+
+  await window.activeTextEditor?.insertSnippet(
+    snippet,
+    position.with(position.line, 0)
+  );
+}
+
+export async function insertBlankSnippetAtNonEmptyLine(
+  lines: string[],
+  position: Position
+): Promise<void> {
+  const snippet = new SnippetString();
+
+  snippet.appendTabstop(0);
+  snippet.appendText(EOL.repeat(lines.length - 1));
+  snippetBlankRange = new Range(
+    position,
+    position.translate(lines.length - 1, -position.character)
+  );
+
+  await window.activeTextEditor?.insertSnippet(
+    snippet,
+    position.with(position.line + 1, 0)
+  );
+
+  await moveCursorBackTo(position);
+}
+
+async function moveCursorBackTo(position: Position) {
+  await commands.executeCommand("cursorMove", { to: "up", by: "line" });
+  await commands.executeCommand("cursorMove", {
+    to: "right",
+    by: "character",
+    value: position.character,
+  });
+}
+
+export async function removeBlankSnippet(): Promise<void> {
+  if (snippetBlankRange) {
+    const fixedRange = calculateStartAfterUserInput(snippetBlankRange);
+
+    const rangeToRemove = fixedRange || snippetBlankRange;
+    const kaki = window.activeTextEditor?.document.lineAt(rangeToRemove.end)
+      .text;
+    const lastLineLength = kaki?.length;
+    await window.activeTextEditor
+      ?.edit((editBuilder) => {
+        editBuilder.delete(
+          new Range(
+            rangeToRemove.start,
+            rangeToRemove.end.translate(0, lastLineLength)
+          )
+        );
+      })
+      .then(() => {
+        snippetBlankRange = undefined;
+      });
+  }
+}
+
+function calculateStartAfterUserInput(range: Range): Range | undefined {
+  const currentPosition = window.activeTextEditor?.selection.active;
+
+  if (currentPosition) {
+    const linesDiff = currentPosition.line - range.start.line;
+    const charsDiff = currentPosition.character - range.start.character;
+    return new Range(
+      range.start.translate(linesDiff, charsDiff),
+      range.end.translate(linesDiff)
+    );
+  }
+
+  return undefined;
+}

--- a/src/inlineSuggestions/snippets/blankSnippet.ts
+++ b/src/inlineSuggestions/snippets/blankSnippet.ts
@@ -81,9 +81,12 @@ export async function removeBlankSnippet(): Promise<void> {
     const fixedRange = calculateStartAfterUserInput(snippetBlankRange);
 
     const rangeToRemove = fixedRange || snippetBlankRange;
-    const kaki = window.activeTextEditor?.document.lineAt(rangeToRemove.end)
-      .text;
-    const lastLineLength = kaki?.length;
+    // a workaround to the issue where `insertSnippet` inserts extra indentation
+    // to the last line: https://github.com/microsoft/vscode/issues/20112
+    const lastLineText = window.activeTextEditor?.document.lineAt(
+      rangeToRemove.end
+    ).text;
+    const lastLineLength = lastLineText?.length;
     await window.activeTextEditor
       ?.edit((editBuilder) => {
         editBuilder.delete(

--- a/src/inlineSuggestions/snippets/snippetProvider.ts
+++ b/src/inlineSuggestions/snippets/snippetProvider.ts
@@ -27,6 +27,6 @@ export default async function requestSnippet(
   await setSuggestionsState(autocompleteResult);
   const currentSuggestion = getCurrentSuggestion();
   if (currentSuggestion) {
-    setInlineSuggestion(document, position, currentSuggestion);
+    await setInlineSuggestion(document, position, currentSuggestion);
   }
 }

--- a/src/inlineSuggestions/textListener.ts
+++ b/src/inlineSuggestions/textListener.ts
@@ -10,7 +10,7 @@ import {
 import runCompletion from "../runCompletion";
 import setInlineSuggestion from "./setInlineSuggestion";
 import clearInlineSuggestionsState from "./clearDecoration";
-import { isInSnippetInsertion } from "./snippets/blankSnippet";
+import { isInSnippetInsertion } from "./snippets/snippetDecoration";
 import { URI_SCHEME_FILE } from "../globals/consts";
 import { sleep } from "../utils/utils";
 import { Capability, isCapabilityEnabled } from "../capabilities/capabilities";
@@ -18,7 +18,6 @@ import getCurrentPosition, {
   isEmptyLinesWithNewlineAutoInsert,
   isOnlyWhitespaces,
 } from "./positionExtracter";
-import { CompletionKind } from "../binary/requests/requests";
 
 const EMPTY_LINE_WARMUP_MILLIS = 110;
 
@@ -51,21 +50,10 @@ export default async function textListener({
       document,
       currentTextPosition
     );
-
-    autocompleteResult?.results.push({
-      ...autocompleteResult.results[0],
-      new_prefix: "test\n  b\nc",
-      completion_kind: CompletionKind.Snippet,
-    });
-    // autocompleteResult?.results.splice(0, autocompleteResult.results.length - 1);
     await setSuggestionsState(autocompleteResult);
     const currentSuggestion = getCurrentSuggestion();
     if (currentSuggestion) {
-      await setInlineSuggestion(
-        document,
-        currentTextPosition,
-        currentSuggestion
-      );
+      setInlineSuggestion(document, currentTextPosition, currentSuggestion);
       return;
     }
     void clearInlineSuggestionsState();

--- a/src/inlineSuggestions/textListener.ts
+++ b/src/inlineSuggestions/textListener.ts
@@ -10,7 +10,7 @@ import {
 import runCompletion from "../runCompletion";
 import setInlineSuggestion from "./setInlineSuggestion";
 import clearInlineSuggestionsState from "./clearDecoration";
-import { isInSnippetInsertion } from "./snippets/snippetDecoration";
+import { isInSnippetInsertion } from "./snippets/blankSnippet";
 import { URI_SCHEME_FILE } from "../globals/consts";
 import { sleep } from "../utils/utils";
 import { Capability, isCapabilityEnabled } from "../capabilities/capabilities";
@@ -18,6 +18,7 @@ import getCurrentPosition, {
   isEmptyLinesWithNewlineAutoInsert,
   isOnlyWhitespaces,
 } from "./positionExtracter";
+import { CompletionKind } from "../binary/requests/requests";
 
 const EMPTY_LINE_WARMUP_MILLIS = 110;
 
@@ -50,10 +51,21 @@ export default async function textListener({
       document,
       currentTextPosition
     );
+
+    autocompleteResult?.results.push({
+      ...autocompleteResult.results[0],
+      new_prefix: "test\n  b\nc",
+      completion_kind: CompletionKind.Snippet,
+    });
+    // autocompleteResult?.results.splice(0, autocompleteResult.results.length - 1);
     await setSuggestionsState(autocompleteResult);
     const currentSuggestion = getCurrentSuggestion();
     if (currentSuggestion) {
-      setInlineSuggestion(document, currentTextPosition, currentSuggestion);
+      await setInlineSuggestion(
+        document,
+        currentTextPosition,
+        currentSuggestion
+      );
       return;
     }
     void clearInlineSuggestionsState();

--- a/src/inlineSuggestions/textListener.ts
+++ b/src/inlineSuggestions/textListener.ts
@@ -10,7 +10,7 @@ import {
 import runCompletion from "../runCompletion";
 import setInlineSuggestion from "./setInlineSuggestion";
 import clearInlineSuggestionsState from "./clearDecoration";
-import { isInSnippetInsertion } from "./snippets/snippetDecoration";
+import { isInSnippetInsertion } from "./snippets/blankSnippet";
 import { URI_SCHEME_FILE } from "../globals/consts";
 import { sleep } from "../utils/utils";
 import { Capability, isCapabilityEnabled } from "../capabilities/capabilities";
@@ -50,10 +50,15 @@ export default async function textListener({
       document,
       currentTextPosition
     );
+
     await setSuggestionsState(autocompleteResult);
     const currentSuggestion = getCurrentSuggestion();
     if (currentSuggestion) {
-      setInlineSuggestion(document, currentTextPosition, currentSuggestion);
+      await setInlineSuggestion(
+        document,
+        currentTextPosition,
+        currentSuggestion
+      );
       return;
     }
     void clearInlineSuggestionsState();

--- a/src/test/suite/blankSnippet.test.ts
+++ b/src/test/suite/blankSnippet.test.ts
@@ -1,0 +1,73 @@
+import * as vscode from "vscode";
+import { expect } from "chai";
+import { afterEach, beforeEach, describe, it } from "mocha";
+import { activate, getDocUri } from "./utils/helper";
+import {
+  getSnippetBlankRange,
+  insertBlankSnippet,
+} from "../../inlineSuggestions/snippets/blankSnippet";
+import {
+  assertRangesAreEqual,
+  clearDocument,
+  makeAChangeInDocument,
+} from "./utils/inline.utils";
+
+const someSnippetLines = "const express = require('express');\nconst app = express(); \napp.get('/', (req, res".split(
+  "\n"
+);
+const someLineText = "con";
+const fileStartPosition = new vscode.Position(0, 0);
+
+describe("Should calculate snippet blank range correctly", () => {
+  const docUri = getDocUri("snippetCompletionBlankRange.txt");
+  let editor: vscode.TextEditor | undefined;
+  beforeEach(async () => {
+    const res = await activate(docUri);
+    editor = res?.editor;
+  });
+
+  afterEach(async () => {
+    editor = editor as vscode.TextEditor;
+    await clearDocument(editor);
+  });
+
+  it("should insert the correct amount of empty lines when inserting blank snippet at empty line", async () => {
+    editor = editor as vscode.TextEditor;
+    await insertBlankSnippet(someSnippetLines, fileStartPosition);
+
+    const expectedRange = new vscode.Range(
+      fileStartPosition,
+      fileStartPosition.translate(someSnippetLines.length - 1)
+    );
+    expect(getSnippetBlankRange()).to.not.be.an("undefined");
+    assertRangesAreEqual(expectedRange, getSnippetBlankRange() as vscode.Range);
+
+    expect(editor.document?.getText()).to.equal(
+      "\n".repeat(someSnippetLines.length - 1)
+    );
+  });
+
+  it("should insert the correct amount of empty lines when inserting blank snippet at non empty line", async () => {
+    editor = editor as vscode.TextEditor;
+    await makeAChangeInDocument(
+      editor,
+      someLineText,
+      new vscode.Range(fileStartPosition, fileStartPosition)
+    );
+    await insertBlankSnippet(
+      someSnippetLines,
+      fileStartPosition.translate(0, someLineText.length)
+    );
+
+    const expectedRange = new vscode.Range(
+      fileStartPosition.translate(0, someLineText.length),
+      fileStartPosition.translate(someSnippetLines.length - 1)
+    );
+    expect(getSnippetBlankRange()).to.not.be.an("undefined");
+    assertRangesAreEqual(expectedRange, getSnippetBlankRange() as vscode.Range);
+
+    expect(editor.document?.getText()).to.equal(
+      `${someLineText}${"\n".repeat(someSnippetLines.length - 1)}`
+    );
+  });
+});

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -15,7 +15,7 @@ export function run(): Promise<void> {
   const testsRoot = path.resolve(__dirname, "..");
 
   return new Promise((c, e) => {
-    glob("**/blankSnippet.test.js", { cwd: testsRoot }, (err, files) => {
+    glob("**/**.test.js", { cwd: testsRoot }, (err, files) => {
       if (err) {
         e(err);
       }

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -15,7 +15,7 @@ export function run(): Promise<void> {
   const testsRoot = path.resolve(__dirname, "..");
 
   return new Promise((c, e) => {
-    glob("**/**.test.js", { cwd: testsRoot }, (err, files) => {
+    glob("**/blankSnippet.test.js", { cwd: testsRoot }, (err, files) => {
       if (err) {
         e(err);
       }

--- a/src/test/suite/snippetBlank.test.ts
+++ b/src/test/suite/snippetBlank.test.ts
@@ -6,11 +6,7 @@ import {
   getSnippetBlankRange,
   insertBlankSnippet,
 } from "../../inlineSuggestions/snippets/blankSnippet";
-import {
-  assertRangesAreEqual,
-  clearDocument,
-  makeAChangeInDocument,
-} from "./utils/inline.utils";
+import { clearDocument, makeAChangeInDocument } from "./utils/inline.utils";
 
 const someSnippetLines = "const express = require('express');\nconst app = express(); \napp.get('/', (req, res".split(
   "\n"
@@ -18,6 +14,9 @@ const someSnippetLines = "const express = require('express');\nconst app = expre
 const someLineText = "con";
 const fileStartPosition = new vscode.Position(0, 0);
 
+/**
+ * Note: for some reason if this test runs before the file `snippet.test.ts` it makes the test fail.
+ */
 describe("Should calculate snippet blank range correctly", () => {
   const docUri = getDocUri("snippetCompletionBlankRange.txt");
   let editor: vscode.TextEditor | undefined;
@@ -39,8 +38,9 @@ describe("Should calculate snippet blank range correctly", () => {
       fileStartPosition,
       fileStartPosition.translate(someSnippetLines.length - 1)
     );
-    expect(getSnippetBlankRange()).to.not.be.an("undefined");
-    assertRangesAreEqual(expectedRange, getSnippetBlankRange() as vscode.Range);
+    const blankRange = getSnippetBlankRange();
+    expect(blankRange).to.not.be.an("undefined");
+    expect(blankRange).deep.equal(expectedRange);
 
     expect(editor.document?.getText()).to.equal(
       "\n".repeat(someSnippetLines.length - 1)
@@ -63,8 +63,9 @@ describe("Should calculate snippet blank range correctly", () => {
       fileStartPosition.translate(0, someLineText.length),
       fileStartPosition.translate(someSnippetLines.length - 1)
     );
-    expect(getSnippetBlankRange()).to.not.be.an("undefined");
-    assertRangesAreEqual(expectedRange, getSnippetBlankRange() as vscode.Range);
+    const blankRange = getSnippetBlankRange();
+    expect(blankRange).to.not.be.an("undefined");
+    expect(blankRange).deep.equal(expectedRange);
 
     expect(editor.document?.getText()).to.equal(
       `${someLineText}${"\n".repeat(someSnippetLines.length - 1)}`

--- a/src/test/suite/snippetBlank.test.ts
+++ b/src/test/suite/snippetBlank.test.ts
@@ -1,3 +1,4 @@
+import { EOL } from "os";
 import * as vscode from "vscode";
 import { expect } from "chai";
 import { afterEach, beforeEach, describe, it } from "mocha";
@@ -43,7 +44,7 @@ describe("Should calculate snippet blank range correctly", () => {
     expect(blankRange).deep.equal(expectedRange);
 
     expect(editor.document?.getText()).to.equal(
-      "\n".repeat(someSnippetLines.length - 1)
+      EOL.repeat(someSnippetLines.length - 1)
     );
   });
 
@@ -68,7 +69,7 @@ describe("Should calculate snippet blank range correctly", () => {
     expect(blankRange).deep.equal(expectedRange);
 
     expect(editor.document?.getText()).to.equal(
-      `${someLineText}${"\n".repeat(someSnippetLines.length - 1)}`
+      `${someLineText}${EOL.repeat(someSnippetLines.length - 1)}`
     );
   });
 });

--- a/src/test/suite/utils/inline.utils.ts
+++ b/src/test/suite/utils/inline.utils.ts
@@ -52,13 +52,3 @@ export function assertTextIncludesTheSuggestion(
     editor.document.getText(new vscode.Range(0, 0, 0, A_SUGGESTION.length))
   ).to.equal(A_SUGGESTION);
 }
-
-export function assertRangesAreEqual(
-  expected: vscode.Range,
-  actual: vscode.Range
-): void {
-  expect(expected.start.line).to.equal(actual.start.line);
-  expect(expected.start.character).to.equal(actual.start.character);
-  expect(expected.end.line).to.equal(actual.end.line);
-  expect(expected.end.character).to.equal(actual.end.character);
-}

--- a/src/test/suite/utils/inline.utils.ts
+++ b/src/test/suite/utils/inline.utils.ts
@@ -22,18 +22,43 @@ export async function acceptTheSuggestion(): Promise<void> {
   await sleep(1000);
 }
 export async function makeAChangeInDocument(
-  editor: vscode.TextEditor
+  editor: vscode.TextEditor,
+  text?: string,
+  range?: vscode.Range
 ): Promise<void> {
   await editor.insertSnippet(
-    new vscode.SnippetString("a"),
-    new vscode.Range(0, 5, 0, 6)
+    new vscode.SnippetString(text || "a"),
+    range || new vscode.Range(0, 5, 0, 6)
   );
   await sleep(1000);
 }
+
+export async function clearDocument(editor: vscode.TextEditor): Promise<void> {
+  const startPosition = new vscode.Position(0, 0);
+  await editor.edit((editBuilder) =>
+    editBuilder.delete(
+      new vscode.Range(
+        startPosition,
+        startPosition.translate(editor.document.lineCount)
+      )
+    )
+  );
+}
+
 export function assertTextIncludesTheSuggestion(
   editor: vscode.TextEditor
 ): void {
   expect(
     editor.document.getText(new vscode.Range(0, 0, 0, A_SUGGESTION.length))
   ).to.equal(A_SUGGESTION);
+}
+
+export function assertRangesAreEqual(
+  expected: vscode.Range,
+  actual: vscode.Range
+): void {
+  expect(expected.start.line).to.equal(actual.start.line);
+  expect(expected.start.character).to.equal(actual.start.character);
+  expect(expected.end.line).to.equal(actual.end.line);
+  expect(expected.end.character).to.equal(actual.end.character);
 }


### PR DESCRIPTION
A follow up to #694
## Make snippets work on non empty lines
Until now, snippets handling was heavily relying on the assumption that snippets will only be shown on newlines. This assumption must break in order to merge snippet completions with regular ones.

### What's been done
1. Extract snippets blank range logic to `blankSnippet.ts`, and make it differentiate between blank insertion on empty vs. non empty lines:
On empty lines it works the same, but for non empty lines it inserts the blank range one line **below** the current position (because we want to present part of the hint in the current line), and then move the cursor back to the correct position.
2. Touch-ups to `src/inlineSuggestions/snippets/snippetDecoration.ts` (where the snippet hint is being constructed) to make it work for both empty and non empty lines.
3. Change `src/inlineSuggestions/snippets/acceptSnippetSuggestion.ts` to override any existing text inside the blank range with the new completion, so that if you start typing `abc` and the snippet is `abcde\nfg`, it **removes** the `abc` and **replaces** it with `abcde\nfg`.
4. Some `awaits` on a few `async`s that were causing bad behaviour.

### Known drawbacks
1. I feel like moving between snippet hints looks a bit less "fluent" now, you can see some flickering while the blank range is being deleted and re-inserted
2. Last line of the snippet hint is one indentation too far - This is a known issue with vscode's snippet insertion api and is being partially handled in `removeBlankSnippet`.