### PR TITLE
feature: add proposed alpha channel

### DIFF
--- a/src/globals/tabnineExtensionProperties.ts
+++ b/src/globals/tabnineExtensionProperties.ts
@@ -27,6 +27,7 @@ interface TabNineExtensionProperties {
   isInstalled: boolean;
   isVscodeTelemetryEnabled: boolean;
   isExtentionBetaChannelEnabled: boolean;
+  isProposedAlphaChannelEnabled: boolean;
   isVscodeInsiders: boolean;
 }
 
@@ -63,7 +64,9 @@ function getContext(): TabNineExtensionProperties {
   }
   const isExtentionBetaChannelEnabled =
     configuration.get<boolean>("tabnine.receiveBetaChannelUpdates") || false;
-
+  const isProposedAlphaChannelEnabled =
+    configuration.get<boolean>("tabnine.receiveProposedAlphaChannelUpdates") ||
+    false;
   const isVscodeInsiders = vscode.env.appName
     .toLocaleLowerCase()
     .includes("insider");
@@ -138,6 +141,9 @@ function getContext(): TabNineExtensionProperties {
     },
     get isExtentionBetaChannelEnabled(): boolean {
       return isExtentionBetaChannelEnabled;
+    },
+    get isProposedAlphaChannelEnabled(): boolean {
+      return isProposedAlphaChannelEnabled;
     },
     get isVscodeInsiders(): boolean {
       return isVscodeInsiders;

--- a/src/preRelease/installer.ts
+++ b/src/preRelease/installer.ts
@@ -18,16 +18,32 @@ import {
   isPreReleaseChannelSupported,
   updatePersistedAlphaVersion,
   userConsumesPreReleaseChannelUpdates,
+  userConsumesProposedAlphaUpdates,
 } from "./versions";
 import { ExtensionContext, GitHubReleaseResponse } from "./types";
 import { Capability, isCapabilityEnabled } from "../capabilities/capabilities";
+
+export const PROPOSED_ALPHA_VERSION = "9999.9999.9999";
+export const PROPOSED_ALPHA_ARTIFACTS_URL = `https://github.com/codota/tabnine-vscode/releases/download/v${PROPOSED_ALPHA_VERSION}/tabnine-vscode-${PROPOSED_ALPHA_VERSION}.vsix`;
 
 export default async function handlePreReleaseChannels(
   context: ExtensionContext
 ): Promise<void> {
   try {
     void showNotificationForBetaChannelIfNeeded(context);
-    if (userConsumesPreReleaseChannelUpdates()) {
+    let downloadedVersion;
+
+    if (userConsumesProposedAlphaUpdates()) {
+      const currentVersion = getCurrentVersion(context);
+      if (currentVersion !== PROPOSED_ALPHA_VERSION) {
+        const { name } = await createTempFileWithPostfix(".vsix");
+        await downloadFileToDestination(PROPOSED_ALPHA_ARTIFACTS_URL, name);
+        await commands.executeCommand(INSTALL_COMMAND, Uri.file(name));
+        await updatePersistedAlphaVersion(context, PROPOSED_ALPHA_VERSION);
+
+        downloadedVersion = PROPOSED_ALPHA_VERSION;
+      }
+    } else if (userConsumesPreReleaseChannelUpdates()) {
       const artifactUrl = await getArtifactUrl();
       const availableVersion = getAvailableAlphaVersion(artifactUrl);
 
@@ -37,14 +53,18 @@ export default async function handlePreReleaseChannels(
         await commands.executeCommand(INSTALL_COMMAND, Uri.file(name));
         await updatePersistedAlphaVersion(context, availableVersion);
 
-        void showMessage({
-          messageId: "prerelease-installer-update",
-          messageText: `TabNine has been updated to ${availableVersion} version. Please reload the window for the changes to take effect.`,
-          buttonText: "Reload",
-          action: () =>
-            void commands.executeCommand("workbench.action.reloadWindow"),
-        });
+        downloadedVersion = availableVersion;
       }
+    }
+
+    if (downloadedVersion) {
+      void showMessage({
+        messageId: "prerelease-installer-update",
+        messageText: `TabNine has been updated to ${downloadedVersion} version. Please reload the window for the changes to take effect.`,
+        buttonText: "Reload",
+        action: () =>
+          void commands.executeCommand("workbench.action.reloadWindow"),
+      });
     }
   } catch (e) {
     console.error(e);

--- a/src/preRelease/versions.ts
+++ b/src/preRelease/versions.ts
@@ -40,6 +40,15 @@ export function isPreReleaseChannelSupported(): boolean {
   );
 }
 
+export function userConsumesProposedAlphaUpdates(): boolean {
+  return (
+    isPreReleaseChannelSupported() &&
+    isCapabilityEnabled(Capability.ALPHA_CAPABILITY) &&
+    tabnineExtensionProperties.isVscodeInsiders &&
+    tabnineExtensionProperties.isProposedAlphaChannelEnabled
+  );
+}
+
 export function userConsumesPreReleaseChannelUpdates(): boolean {
   return (
     isPreReleaseChannelSupported() &&

--- a/src/test/suite/preReleaseInstallerProposedAlpha.test.ts
+++ b/src/test/suite/preReleaseInstallerProposedAlpha.test.ts
@@ -1,0 +1,75 @@
+import * as sinon from "sinon";
+import { afterEach, beforeEach } from "mocha";
+import {
+  assertSuccessfulInstalled,
+  assertWasNotInstalled,
+  initMocks,
+  runInstallation,
+} from "./utils/preReleaseInstaller.utils";
+import { PROPOSED_ALPHA_VERSION } from "../../preRelease/installer";
+
+suite("Should update proposed alpha release", () => {
+  beforeEach(initMocks);
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  test("in case of not alpha, do nothing", async () => {
+    await runInstallation("v3.1.11", PROPOSED_ALPHA_VERSION, {
+      isAlpha: false,
+      isInsidersApp: true,
+      isProposedAlphaChannelEnabled: true,
+    });
+
+    assertWasNotInstalled();
+  });
+  test("in case of proposed alpha channel disabled, do nothing", async () => {
+    await runInstallation("v3.1.11", PROPOSED_ALPHA_VERSION, {
+      isAlpha: true,
+      isInsidersApp: true,
+      isProposedAlphaChannelEnabled: false,
+    });
+
+    assertWasNotInstalled();
+  });
+  test("in case of not insiders, do nothing", async () => {
+    await runInstallation("v3.1.11", PROPOSED_ALPHA_VERSION, {
+      isAlpha: true,
+      isInsidersApp: false,
+      isProposedAlphaChannelEnabled: true,
+    });
+
+    assertWasNotInstalled();
+  });
+  test("in case of unsupported vscode version, do nothing", async () => {
+    await runInstallation("v3.1.11", PROPOSED_ALPHA_VERSION, {
+      isAlpha: true,
+      isInsidersApp: true,
+      vscodeVersion: "1.32.0",
+      isProposedAlphaChannelEnabled: true,
+    });
+
+    assertWasNotInstalled();
+  });
+  [PROPOSED_ALPHA_VERSION, "v3.1.11"].forEach((version) =>
+    test(`in case of current version is the proposed alpha version, do not install version ${version}`, async () => {
+      await runInstallation(PROPOSED_ALPHA_VERSION, version, {
+        isAlpha: true,
+        isInsidersApp: true,
+        isProposedAlphaChannelEnabled: true,
+      });
+
+      assertWasNotInstalled();
+    })
+  );
+  test("in case of current version is not the proposed alpha version, install it", async () => {
+    await runInstallation("v3.1.11", PROPOSED_ALPHA_VERSION, {
+      isAlpha: true,
+      isInsidersApp: true,
+      isProposedAlphaChannelEnabled: true,
+    });
+
+    assertSuccessfulInstalled(PROPOSED_ALPHA_VERSION);
+  });
+});

--- a/src/test/suite/utils/preReleaseInstaller.utils.ts
+++ b/src/test/suite/utils/preReleaseInstaller.utils.ts
@@ -92,7 +92,6 @@ export async function runInstallation(
   );
   installedVersion.value(installed);
   const artifactUrl = getArtifactUrl(available);
-  console.log(artifactUrl);
   mockHttp(
     [[{ assets: [{ browser_download_url: artifactUrl }] }], LATEST_RELEASE_URL],
     [{ data: "test" }, artifactUrl],


### PR DESCRIPTION
i created a hard coded release: https://github.com/codota/tabnine-vscode/releases/tag/v9999.9999.9999 which i manually added the vsix file to,
and made the plugin download this particular version if:
- you're alpha
- you're using insiders
- your vscode version is high enough
- you've enabled `tabnine.receiveProposedAlphaChannelUpdates`
To enable this property, open vscode's `settings.json` 
![image](https://user-images.githubusercontent.com/67855609/144431751-6c0d839b-8461-41b8-92f0-33bff77afa10.png)
and add:
```json
"tabnine.receiveProposedAlphaChannelUpdates": true
```