### PR TITLE
fix: check minimal authentication provider api version

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,6 +52,7 @@ import registerTreeView from "./treeView/registerTreeView";
 import { closeAssistant } from "./assistant/requests/request";
 import initAssistant from "./assistant/AssistantClient";
 import TabnineAuthenticationProvider from "./authentication/TabnineAuthenticationProvider";
+import isAuthenticationApiSupported from "./globals/versions";
 
 export async function activate(
   context: vscode.ExtensionContext
@@ -92,7 +93,10 @@ async function backgroundInit(context: vscode.ExtensionContext) {
   // Goes to the binary to fetch what capabilities enabled:
   await fetchCapabilitiesOnFocus();
 
-  if (isCapabilityEnabled(Capability.AUTHENTICATION)) {
+  if (
+    isCapabilityEnabled(Capability.AUTHENTICATION) &&
+    isAuthenticationApiSupported()
+  ) {
     context.subscriptions.push(
       vscode.authentication.registerAuthenticationProvider(
         BRAND_NAME,

--- a/src/globals/versions.ts
+++ b/src/globals/versions.ts
@@ -1,5 +1,6 @@
 import * as semver from "semver";
 import tabnineExtensionProperties from "./tabnineExtensionProperties";
+
 const AUTHENTICATION_API_VERSION = "1.54.0";
 
 export default function isAuthenticationApiSupported(): boolean {

--- a/src/globals/versions.ts
+++ b/src/globals/versions.ts
@@ -1,0 +1,11 @@
+import * as semver from "semver";
+import tabnineExtensionProperties from "./tabnineExtensionProperties";
+
+
+export default function isAuthenticationApiSupported(): boolean {
+    const AUTHENTICATION_API_VERSION = "1.54.0";
+    return semver.gte(
+      tabnineExtensionProperties.vscodeVersion,
+      AUTHENTICATION_API_VERSION
+    );
+  }

--- a/src/globals/versions.ts
+++ b/src/globals/versions.ts
@@ -1,11 +1,10 @@
 import * as semver from "semver";
 import tabnineExtensionProperties from "./tabnineExtensionProperties";
-
+const AUTHENTICATION_API_VERSION = "1.54.0";
 
 export default function isAuthenticationApiSupported(): boolean {
-    const AUTHENTICATION_API_VERSION = "1.54.0";
-    return semver.gte(
-      tabnineExtensionProperties.vscodeVersion,
-      AUTHENTICATION_API_VERSION
-    );
-  }
+  return semver.gte(
+    tabnineExtensionProperties.vscodeVersion,
+    AUTHENTICATION_API_VERSION
+  );
+}


### PR DESCRIPTION
check the minimal [`registerAuthenticationProvider`](https://code.visualstudio.com/updates/v1_54#_authentication-provider-api) version.  this api was supported in the  [1.54](https://code.visualstudio.com/updates/v1_54) version