### PR TITLE
repackaging feb22 - show 'tabnine team' in statusbar

### DIFF
--- a/src/binary/state.ts
+++ b/src/binary/state.ts
@@ -28,6 +28,7 @@ export enum EmuMode {
 export type ServiceLevel =
   | "Free"
   | "Pro"
+  | "Old Pro"
   | "Trial"
   | "Trial Expired"
   | "Lite"

--- a/src/binary/state.ts
+++ b/src/binary/state.ts
@@ -28,7 +28,6 @@ export enum EmuMode {
 export type ServiceLevel =
   | "Free"
   | "Pro"
-  | "Old Pro"
   | "Trial"
   | "Trial Expired"
   | "Lite"

--- a/src/statusBar/StatusBarData.ts
+++ b/src/statusBar/StatusBarData.ts
@@ -74,8 +74,12 @@ export default class StatusBarData {
       return " business";
     }
 
+    if (this._serviceLevel === "Old Pro") {
+      return " pro";
+    }
+
     return this._serviceLevel === "Pro" || this._serviceLevel === "Trial"
-      ? " pro"
+      ? " team"
       : "";
   }
 

--- a/src/statusBar/StatusBarData.ts
+++ b/src/statusBar/StatusBarData.ts
@@ -73,14 +73,11 @@ export default class StatusBarData {
     if (this._serviceLevel === "Business") {
       return " business";
     }
-
-    if (this._serviceLevel === "Old Pro") {
+    if (this._serviceLevel === "Trial") {
       return " pro";
     }
 
-    return this._serviceLevel === "Pro" || this._serviceLevel === "Trial"
-      ? " team"
-      : "";
+    return this._serviceLevel === "Pro" ? " team" : "";
   }
 
   private getIconText(): string {

--- a/src/statusBar/statusBar.ts
+++ b/src/statusBar/statusBar.ts
@@ -1,6 +1,5 @@
 import { ExtensionContext, StatusBarAlignment, window } from "vscode";
 import { getState } from "../binary/requests/requests";
-import { ServiceLevel, State } from "../binary/state";
 import { STATUS_BAR_COMMAND } from "../commandsHandler";
 import { FULL_BRAND_REPRESENTATION, STATUS_NAME } from "../globals/consts";
 import StatusBarData from "./StatusBarData";
@@ -40,7 +39,8 @@ export async function pollServiceLevel(): Promise<void> {
     return;
   }
 
-  statusBarData.serviceLevel = getDisplayServiceLevel(await getState());
+  const state = await getState();
+  statusBarData.serviceLevel = state?.service_level;
 }
 
 export function promotionTextIs(text: string): boolean {
@@ -52,22 +52,8 @@ export async function onStartServiceLevel(): Promise<void> {
     return;
   }
 
-  statusBarData.serviceLevel = getDisplayServiceLevel(await getState());
-}
-
-function getDisplayServiceLevel(
-  state: State | undefined | null
-): ServiceLevel | undefined {
-  const originalServiceLevel = state?.service_level;
-  return originalServiceLevel === "Free" || originalServiceLevel === "Trial"
-    ? serviceLevelBaseOnAPIKey(state)
-    : originalServiceLevel;
-}
-
-function serviceLevelBaseOnAPIKey(
-  state: State | undefined | null
-): ServiceLevel {
-  return state?.api_key ? "Old Pro" : "Free";
+  const state = await getState();
+  statusBarData.serviceLevel = state?.service_level;
 }
 
 export function setDefaultStatus(): void {

--- a/src/statusBar/statusBar.ts
+++ b/src/statusBar/statusBar.ts
@@ -40,9 +40,7 @@ export async function pollServiceLevel(): Promise<void> {
     return;
   }
 
-  const state = await getState();
-
-  statusBarData.serviceLevel = state?.service_level;
+  statusBarData.serviceLevel = getDisplayServiceLevel(await getState());
 }
 
 export function promotionTextIs(text: string): boolean {
@@ -54,16 +52,22 @@ export async function onStartServiceLevel(): Promise<void> {
     return;
   }
 
-  const state = await getState();
-
-  statusBarData.serviceLevel =
-    state?.service_level === "Free"
-      ? serviceLevelBaseOnAPIKey(state)
-      : state?.service_level;
+  statusBarData.serviceLevel = getDisplayServiceLevel(await getState());
 }
 
-function serviceLevelBaseOnAPIKey(state: State): ServiceLevel {
-  return state?.api_key ? "Pro" : "Free";
+function getDisplayServiceLevel(
+  state: State | undefined | null
+): ServiceLevel | undefined {
+  const originalServiceLevel = state?.service_level;
+  return originalServiceLevel === "Free" || originalServiceLevel === "Trial"
+    ? serviceLevelBaseOnAPIKey(state)
+    : originalServiceLevel;
+}
+
+function serviceLevelBaseOnAPIKey(
+  state: State | undefined | null
+): ServiceLevel {
+  return state?.api_key ? "Old Pro" : "Free";
 }
 
 export function setDefaultStatus(): void {


### PR DESCRIPTION
need to show "tabnine team" for paid customers, but show "tabnine pro" for legacy pro + students