### PR TITLE
conditionally import provideInlineCompletionItems

### DIFF
--- a/src/inlineSuggestions/registerHandlers.ts
+++ b/src/inlineSuggestions/registerHandlers.ts
@@ -25,7 +25,6 @@ import {
   StatePayload,
 } from "../globals/consts";
 import enableProposed from "../globals/proposedAPI";
-import provideInlineCompletionItems from "../provideInlineCompletionItems";
 import { initTracker } from "./stateTracker";
 import acceptInlineSuggestion from "./acceptInlineSuggestion";
 import clearInlineSuggestionsState from "./clearDecoration";
@@ -75,6 +74,9 @@ export default async function registerInlineHandlers(
   if (!inlineEnabled && !snippetsEnabled) return;
 
   if (await isDefaultAPIEnabled()) {
+    const provideInlineCompletionItems = (
+      await import("../provideInlineCompletionItems")
+    ).default;
     const inlineCompletionsProvider = {
       provideInlineCompletionItems,
     };


### PR DESCRIPTION
**problem:**  

the `provideInlineCompletionItems` is imports  he  `TabnineInlineCompletionItem` witch imports the `TabnineInlineCompletionItem` that extends from  the `InlineCompletionItem` that does not exists below 1.53.0 version


**solution:**  

conditionally import  the `provideInlineCompletionItems` after the supported version check is done