### PR TITLE
match non word characters

### DIFF
--- a/src/binary/requests/completionPostProcess.ts
+++ b/src/binary/requests/completionPostProcess.ts
@@ -58,7 +58,7 @@ function calculateTrimmingIndex(
  * followed by any text or another \n.
  */
 function constructRegex(indentation: number): RegExp {
-  return RegExp(`^ {0,${indentation - 1}}(\\w|\n)+`, "m");
+  return RegExp(`^ {0,${indentation - 1}}(\\W|\\w|\n)+`, "m");
 }
 
 /**


### PR DESCRIPTION

**Problem**: the suggestion in the attached screenshot was  `);\n  }\n}`. the trimming regex didn't catch the `}` after the current line.

![Screen Shot 2022-06-09 at 15 56 31](https://user-images.githubusercontent.com/60742964/172880877-6ea304c1-c936-4793-8f26-b5bfdf9f5505.png)
