### PR TITLE
fix: use process.env.VSCODE_PROXY_URI

### DIFF
--- a/src/cloudEnvs/openLogin.ts
+++ b/src/cloudEnvs/openLogin.ts
@@ -2,11 +2,12 @@ import { env, Uri } from "vscode";
 import { configuration } from "../binary/requests/requests";
 import { StateType } from "../globals/consts";
 import openHub from "../hub/openHub";
+import { getExternalUri } from "../utils/utils";
 
 export default async function openLogin(): Promise<void> {
   const config = await configuration({ quiet: true, source: StateType.AUTH });
   if (config && config.message) {
-    const localUri = await env.asExternalUri(Uri.parse(config.message));
+    const localUri = await env.asExternalUri(getExternalUri(config.message));
     const callback = `https://app.tabnine.com/auth/sign-in?tabnineUrl=${localUri.toString()}&sync=false`;
     await openHub(localUri);
     void env.openExternal(Uri.parse(callback));

--- a/src/commandsHandler.ts
+++ b/src/commandsHandler.ts
@@ -1,4 +1,4 @@
-import { commands, ExtensionContext, Uri, env } from "vscode";
+import { commands, ExtensionContext, env } from "vscode";
 import openHub from "./hub/openHub";
 import {
   StatePayload,
@@ -11,6 +11,7 @@ import { Capability, isCapabilityEnabled } from "./capabilities/capabilities";
 import handleSaveSnippet, {
   enableSaveSnippetContext,
 } from "./saveSnippetHandler";
+import { getExternalUri } from "./utils/utils";
 
 export const CONFIG_COMMAND = "TabNine::config";
 export const STATUS_BAR_COMMAND = "TabNine.statusBar";
@@ -56,7 +57,7 @@ export function openConfigWithSource(type: StateType) {
   return async (args: string[] | null = null): Promise<void> => {
     const config = await configuration({ quiet: true, source: type });
     if (config && config.message) {
-      const localUri = await env.asExternalUri(Uri.parse(config.message));
+      const localUri = await env.asExternalUri(getExternalUri(config.message));
       void openHub(localUri);
     }
 

--- a/src/treeView/navigate.ts
+++ b/src/treeView/navigate.ts
@@ -1,7 +1,8 @@
-import { env, Uri } from "vscode";
+import { env } from "vscode";
 import { configuration } from "../binary/requests/requests";
 import { StateType } from "../globals/consts";
 import openHub from "../hub/openHub";
+import { getExternalUri } from "../utils/utils";
 
 export default async function navigate(view?: string): Promise<void> {
   const config = await configuration({
@@ -9,7 +10,7 @@ export default async function navigate(view?: string): Promise<void> {
     source: StateType.TREE_VIEW,
   });
   if (config && config.message) {
-    const localUri = await env.asExternalUri(Uri.parse(config.message));
+    const localUri = await env.asExternalUri(getExternalUri(config.message));
     void openHub(localUri, view);
   }
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -76,3 +76,8 @@ export function escapeTabStopSign(value: string): string {
 export function isMultiline(text?: string): boolean {
   return text?.includes("\n") || false;
 }
+
+export function getExternalUri(configMessage: string) {
+  const externalUri = process.env.VSCODE_PROXY_URI ? process.env.VSCODE_PROXY_URI.replace("{{port}}", "5555") : vscode.URI.parse(configMessage) 
+  return externalUri
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,4 @@
+import { URL } from "url";
 import * as vscode from "vscode";
 
 export function withPolling(
@@ -77,7 +78,14 @@ export function isMultiline(text?: string): boolean {
   return text?.includes("\n") || false;
 }
 
-export function getExternalUri(configMessage: string) {
-  const externalUri = process.env.VSCODE_PROXY_URI ? process.env.VSCODE_PROXY_URI.replace("{{port}}", "5555") : vscode.URI.parse(configMessage) 
-  return externalUri
+export function getExternalUri(configMessage: string): vscode.Uri {
+  try {
+    const port = new URL(configMessage).port;
+    const externalUri = process.env.VSCODE_PROXY_URI
+      ? vscode.Uri.parse(process.env.VSCODE_PROXY_URI.replace("{{port}}", port))
+      : vscode.Uri.parse(configMessage);
+    return externalUri;
+  } catch (error) {
+    return vscode.Uri.parse(configMessage);
+  }
 }


### PR DESCRIPTION
> **Warning**
> This requires changes to the Tabnine server before it will work correctly.

This adds a new util function called `getExternalUri` which checks for
`process.env.VSCODE_PROXY_URI` and uses that with the external uri so
that Tabnine can work in environments like code-server, Codespaces,
Gitpod.

co-written with @code-asher