### PR TITLE
override tab key for inline

### DIFF
--- a/package.json
+++ b/package.json
@@ -336,6 +336,11 @@
 				"when": "tabnine.snippet-suggestion:enabled && tabnine.in-inline-suggestions || tabnine.inline-suggestion:enabled && tabnine.in-inline-suggestions"
 			},
 			{
+				"key": "tab",
+				"command": "tabnine.tab-override",
+				"when": "tabnine.tab-override && suggestWidgetVisible && textInputFocus"
+			},
+			{
 				"key": "escape",
 				"command": "tabnine.escape-inline-suggestion",
 				"when": "tabnine.snippet-suggestion:enabled && tabnine.in-inline-suggestions || tabnine.inline-suggestion:enabled && tabnine.in-inline-suggestions"

--- a/src/getAutoImportCommand.ts
+++ b/src/getAutoImportCommand.ts
@@ -1,0 +1,24 @@
+import * as vscode from "vscode";
+import { AutocompleteResult, ResultEntry } from "./binary/requests/requests";
+import { COMPLETION_IMPORTS } from "./selectionHandler";
+
+export default function getAutoImportCommand(
+  result: ResultEntry,
+  response: AutocompleteResult | undefined,
+  position: vscode.Position
+): vscode.Command {
+  return {
+    arguments: [
+      {
+        currentCompletion: result.new_prefix,
+        completions: response?.results,
+        position,
+        limited: response?.is_locked,
+        snippetIntent: response?.snippet_intent,
+        oldPrefix: response?.old_prefix,
+      },
+    ],
+    command: COMPLETION_IMPORTS,
+    title: "accept completion",
+  };
+}

--- a/src/globals/consts.ts
+++ b/src/globals/consts.ts
@@ -139,6 +139,7 @@ export const IS_OSX = process.platform === "darwin";
 export const SLEEP_TIME_BEFORE_OPEN_HUB = isCloudEnv ? 1000 * 10 : 0;
 
 export const ACCEPT_INLINE_COMMAND = "tabnine.accept-inline-suggestion";
+export const TAB_OVERRIDE_COMMAND = "tabnine.tab-override";
 export const ESCAPE_INLINE_COMMAND = "tabnine.escape-inline-suggestion";
 export const NEXT_INLINE_COMMAND = "tabnine.next-inline-suggestion";
 export const PREV_INLINE_COMMAND = "tabnine.prev-inline-suggestion";

--- a/src/inlineSuggestions/registerHandlers.ts
+++ b/src/inlineSuggestions/registerHandlers.ts
@@ -107,7 +107,9 @@ export default async function registerInlineHandlers(
   return subscriptions;
 }
 
-async function initTabOverrideForAlpha(subscriptions: Disposable[]) {
+async function initTabOverrideForAlpha(
+  subscriptions: Disposable[]
+): Promise<void> {
   if (isCapabilityEnabled(Capability.ALPHA_CAPABILITY)) {
     subscriptions.push(await enableTabOverrideContext(), registerTabOverride());
   }

--- a/src/inlineSuggestions/tabnineInlineCompletionItem.ts
+++ b/src/inlineSuggestions/tabnineInlineCompletionItem.ts
@@ -8,6 +8,8 @@ export default class TabnineInlineCompletionItem extends InlineCompletionItem {
 
   snippetIntent?: UserIntent;
 
+  insertText?: string;
+
   constructor(
     text: string,
     range?: Range,

--- a/src/lookAheadSuggestion.ts
+++ b/src/lookAheadSuggestion.ts
@@ -85,27 +85,21 @@ function registerTabOverride(): Disposable {
   return commands.registerTextEditorCommand(
     `${TAB_OVERRIDE_COMMAND}`,
     (_textEditor: TextEditor, edit: TextEditorEdit) => {
-      const { range, insertText } = currentLookAheadSuggestion ?? {
-        range: undefined,
-        insertTex: undefined,
-      };
+      if (!currentLookAheadSuggestion) {
+        void commands.executeCommand("acceptSelectedSuggestion");
+        return;
+      }
+
+      const { range, insertText } = currentLookAheadSuggestion;
       if (range && insertText) {
         edit.replace(range, insertText);
-      } else {
-        void commands.executeCommand("acceptSelectedSuggestion");
       }
     }
   );
 }
+
 async function enableTabOverrideContext(): Promise<Disposable> {
-  const res = await commands.executeCommand(
-    "setContext",
-    "tabnine.tab-override",
-    true
-  );
-
-  console.log("res after enableTabOverrideContext: ", res);
-
+  await commands.executeCommand("setContext", "tabnine.tab-override", true);
   return {
     dispose() {
       void commands.executeCommand(

--- a/src/lookAheadSuggestion.ts
+++ b/src/lookAheadSuggestion.ts
@@ -1,0 +1,118 @@
+import {
+  commands,
+  Disposable,
+  InlineCompletionList,
+  Position,
+  SelectedCompletionInfo,
+  TextDocument,
+  TextEditor,
+  TextEditorEdit,
+} from "vscode";
+import { AutocompleteResult, ResultEntry } from "./binary/requests/requests";
+import { Capability, isCapabilityEnabled } from "./capabilities/capabilities";
+import getAutoImportCommand from "./getAutoImportCommand";
+import { TAB_OVERRIDE_COMMAND } from "./globals/consts";
+import TabnineInlineCompletionItem from "./inlineSuggestions/tabnineInlineCompletionItem";
+import runCompletion from "./runCompletion";
+import retry from "./utils/retry";
+
+// this will track only the suggestion which is "extending" the completion popup selected item,
+// i.e. it is relevant only for case where both are presented popup and inline
+let currentLookAheadSuggestion: TabnineInlineCompletionItem | undefined | null;
+
+export function clearCurrentLookAheadSuggestion(): void {
+  currentLookAheadSuggestion = undefined;
+}
+export async function initTabOverrideForAlpha(
+  subscriptions: Disposable[]
+): Promise<void> {
+  if (isCapabilityEnabled(Capability.ALPHA_CAPABILITY)) {
+    console.log("initTabOverrideForAlpha");
+    subscriptions.push(await enableTabOverrideContext(), registerTabOverride());
+  }
+}
+
+// "look a head " suggestion
+// is the suggestion witch extends te current selected intellisense popup item
+// and queries tabnine with the selected item as prefix untitled-file-extension
+export async function getLookAheadSuggestion(
+  document: TextDocument,
+  completionInfo: SelectedCompletionInfo,
+  position: Position
+): Promise<InlineCompletionList<TabnineInlineCompletionItem>> {
+  const response = await retry(
+    () =>
+      runCompletion(
+        document,
+        completionInfo.range.start,
+        undefined,
+        completionInfo.text
+      ),
+    (res) => !res?.results.length,
+    2
+  );
+
+  const result = findMostRelevantSuggestion(response, completionInfo);
+  const completion =
+    result &&
+    response &&
+    new TabnineInlineCompletionItem(
+      result.new_prefix.replace(response.old_prefix, completionInfo.text),
+      completionInfo.range,
+      getAutoImportCommand(result, response, position),
+      result.completion_kind,
+      result.is_cached,
+      response.snippet_intent
+    );
+
+  currentLookAheadSuggestion = completion;
+
+  return new InlineCompletionList((completion && [completion]) || []);
+}
+
+function findMostRelevantSuggestion(
+  response: AutocompleteResult | null | undefined,
+  completionInfo: SelectedCompletionInfo
+): ResultEntry | undefined {
+  return response?.results
+    .filter(({ new_prefix }) => new_prefix.startsWith(completionInfo.text))
+    .sort(
+      (a, b) => parseInt(b.detail || "", 10) - parseInt(a.detail || "", 10)
+    )[0];
+}
+
+function registerTabOverride(): Disposable {
+  return commands.registerTextEditorCommand(
+    `${TAB_OVERRIDE_COMMAND}`,
+    (_textEditor: TextEditor, edit: TextEditorEdit) => {
+      const { range, insertText } = currentLookAheadSuggestion ?? {
+        range: undefined,
+        insertTex: undefined,
+      };
+      if (range && insertText) {
+        edit.replace(range, insertText);
+      } else {
+        void commands.executeCommand("acceptSelectedSuggestion");
+      }
+    }
+  );
+}
+async function enableTabOverrideContext(): Promise<Disposable> {
+  const res = await commands.executeCommand(
+    "setContext",
+    "tabnine.tab-override",
+    true
+  );
+
+  console.log("res after enableTabOverrideContext: ", res);
+
+  return {
+    dispose() {
+      void commands.executeCommand(
+        "setContext",
+        "tabnine.tab-override",
+        undefined
+      );
+    },
+  };
+}

--- a/src/provideInlineCompletionItems.ts
+++ b/src/provideInlineCompletionItems.ts
@@ -9,11 +9,21 @@ import retry from "./utils/retry";
 
 const INLINE_REQUEST_TIMEOUT = 3000;
 
+let lastPrediction: TabnineInlineCompletionItem | undefined | null;
+
+export function getLastPrediction():
+  | TabnineInlineCompletionItem
+  | undefined
+  | null {
+  return lastPrediction;
+}
+
 export default async function provideInlineCompletionItems(
   document: vscode.TextDocument,
   position: vscode.Position,
   context: vscode.InlineCompletionContext
 ): Promise<vscode.InlineCompletionList<TabnineInlineCompletionItem>> {
+  lastPrediction = undefined;
   try {
     if (
       !completionIsAllowed(document, position) ||
@@ -96,6 +106,8 @@ async function getCompletionsExtendingSelectedItem(
       result.is_cached,
       response.snippet_intent
     );
+
+  lastPrediction = completion;
 
   return new vscode.InlineCompletionList((completion && [completion]) || []);
 }

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -18,7 +18,7 @@ import {
   makeAChange,
   mockAutocomplete,
   moveToActivePosition,
-  openADocAndMakeChange,
+  openADocWith,
   triggerInline,
   triggerPopupSuggestion,
   triggerSelectionAppetence,
@@ -82,7 +82,7 @@ describe("Should do completion", () => {
     );
   });
   it("should prefer the popup when only popup is visible and there is no inline suggestion", async () => {
-    await openADocAndMakeChange("cons", "o");
+    (await openADocWith("cons")).makeAChange("o");
 
     await triggerPopupSuggestion();
 
@@ -93,7 +93,7 @@ describe("Should do completion", () => {
     assertTextIsCommitted("console");
   });
   it("should prefer an inline when both popup and inline are visible", async () => {
-    await openADocAndMakeChange("cons", "o");
+    (await openADocWith("cons")).makeAChange("o");
 
     await triggerPopupSuggestion();
 

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -13,14 +13,17 @@ import {
 } from "../../binary/mockedRunProcess";
 import {
   acceptInline,
+  assertTextIsCommitted,
   completion,
-  emulationUserInteraction,
   makeAChange,
   mockAutocomplete,
   moveToActivePosition,
+  openADocAndMakeChange,
   triggerInline,
+  triggerPopupSuggestion,
+  triggerSelectionAppetence,
 } from "./utils/completion.utils";
-import { activate, getDocUri, openDocument } from "./utils/helper";
+import { activate, getDocUri } from "./utils/helper";
 import {
   aCompletionResult,
   anAutocompleteResponse,
@@ -31,7 +34,6 @@ import {
 import { AutocompleteRequestMatcher } from "./utils/AutocompleteRequestMatcher";
 import { resetBinaryForTesting } from "../../binary/requests/requests";
 import { sleep } from "../../utils/utils";
-import { TAB_OVERRIDE_COMMAND } from "../../globals/consts";
 
 describe("Should do completion", () => {
   const docUri = getDocUri("completion.txt");
@@ -105,33 +107,9 @@ describe("Should do completion", () => {
   });
 });
 
-function mockInlineResponse() {
+function mockInlineResponse(): void {
   mockAutocomplete(
     requestResponseItems,
     anAutocompleteResponse("console", "console.log")
   );
-}
-
-function assertTextIsCommitted(expected: string) {
-  expect(vscode.window.activeTextEditor?.document.getText()).to.equal(expected);
-}
-
-async function triggerSelectionAppetence() {
-  await emulationUserInteraction();
-
-  await vscode.commands.executeCommand(TAB_OVERRIDE_COMMAND);
-
-  await emulationUserInteraction();
-}
-
-async function triggerPopupSuggestion() {
-  await emulationUserInteraction();
-  await vscode.commands.executeCommand("editor.action.triggerSuggest");
-}
-
-async function openADocAndMakeChange(content: string, change: string) {
-  await openDocument("javascript", content);
-  await isProcessReadyForTest();
-  await moveToActivePosition();
-  await makeAChange(change);
 }

--- a/src/test/suite/utils/completion.utils.ts
+++ b/src/test/suite/utils/completion.utils.ts
@@ -8,6 +8,7 @@ import { BinaryGenericRequest } from "./helper";
 import { isProcessReadyForTest, Item } from "../../../binary/mockedRunProcess";
 import { SelectionStateRequest } from "../../../binary/requests/setState";
 import { CompletionArguments } from "../../../CompletionArguments";
+import { sleep } from "../../../utils/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 chaiUse(require("chai-shallow-deep-equal"));
@@ -45,7 +46,6 @@ export function selectionCommandArgs(
     oldPrefix: result.old_prefix,
   };
 }
-
 export function mockAutocomplete(
   requestResponseItems: Item[],
   result: AutocompleteResult
@@ -54,8 +54,36 @@ export function mockAutocomplete(
     isQualified: (request) => {
       const completionRequest = JSON.parse(request) as AutocompleteRequest;
 
-      return !!completionRequest?.request?.Autocomplete;
+      return (
+        !!completionRequest?.request?.Autocomplete &&
+        completionRequest?.request?.Autocomplete.before.endsWith(
+          result.old_prefix
+        )
+      );
     },
     result,
   });
+}
+export async function acceptInline(): Promise<unknown> {
+  return vscode.commands.executeCommand("editor.action.inlineSuggest.commit");
+}
+
+export async function triggerInline(): Promise<unknown> {
+  return vscode.commands.executeCommand("editor.action.inlineSuggest.trigger");
+}
+
+export async function makeAChange(text: string): Promise<boolean | undefined> {
+  return vscode.window.activeTextEditor?.insertSnippet(
+    new vscode.SnippetString(text),
+    vscode.window.activeTextEditor?.selection.active
+  );
+}
+
+export async function moveToActivePosition(): Promise<unknown> {
+  return vscode.commands.executeCommand("cursorMove", {
+    to: "wrappedLineEnd",
+  });
+}
+export async function emulationUserInteraction(): Promise<void> {
+  await sleep(400);
 }

--- a/src/test/suite/utils/completion.utils.ts
+++ b/src/test/suite/utils/completion.utils.ts
@@ -69,6 +69,7 @@ export async function acceptInline(): Promise<unknown> {
 }
 
 export async function triggerInline(): Promise<unknown> {
+  await emulationUserInteraction();
   return vscode.commands.executeCommand("editor.action.inlineSuggest.trigger");
 }
 

--- a/src/test/suite/utils/completion.utils.ts
+++ b/src/test/suite/utils/completion.utils.ts
@@ -107,12 +107,14 @@ export async function triggerPopupSuggestion(): Promise<void> {
   await vscode.commands.executeCommand("editor.action.triggerSuggest");
 }
 
-export async function openADocAndMakeChange(
-  content: string,
-  change: string
-): Promise<void> {
+export async function openADocWith(
+  content: string
+): Promise<{ makeAChange: (change: string) => void }> {
   await openDocument("javascript", content);
   await isProcessReadyForTest();
   await moveToActivePosition();
-  await makeAChange(change);
+
+  return {
+    makeAChange,
+  };
 }

--- a/src/test/suite/utils/completion.utils.ts
+++ b/src/test/suite/utils/completion.utils.ts
@@ -1,14 +1,15 @@
 import * as vscode from "vscode";
-import { use as chaiUse } from "chai";
+import { expect, use as chaiUse } from "chai";
 import {
   AutocompleteParams,
   AutocompleteResult,
 } from "../../../binary/requests/requests";
-import { BinaryGenericRequest } from "./helper";
+import { BinaryGenericRequest, openDocument } from "./helper";
 import { isProcessReadyForTest, Item } from "../../../binary/mockedRunProcess";
 import { SelectionStateRequest } from "../../../binary/requests/setState";
 import { CompletionArguments } from "../../../CompletionArguments";
 import { sleep } from "../../../utils/utils";
+import { TAB_OVERRIDE_COMMAND } from "../../../globals/consts";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 chaiUse(require("chai-shallow-deep-equal"));
@@ -87,4 +88,31 @@ export async function moveToActivePosition(): Promise<unknown> {
 }
 export async function emulationUserInteraction(): Promise<void> {
   await sleep(400);
+}
+
+export function assertTextIsCommitted(expected: string): void {
+  expect(vscode.window.activeTextEditor?.document.getText()).to.equal(expected);
+}
+
+export async function triggerSelectionAppetence(): Promise<void> {
+  await emulationUserInteraction();
+
+  await vscode.commands.executeCommand(TAB_OVERRIDE_COMMAND);
+
+  await emulationUserInteraction();
+}
+
+export async function triggerPopupSuggestion(): Promise<void> {
+  await emulationUserInteraction();
+  await vscode.commands.executeCommand("editor.action.triggerSuggest");
+}
+
+export async function openADocAndMakeChange(
+  content: string,
+  change: string
+): Promise<void> {
+  await openDocument("javascript", content);
+  await isProcessReadyForTest();
+  await moveToActivePosition();
+  await makeAChange(change);
 }

--- a/src/test/suite/utils/helper.ts
+++ b/src/test/suite/utils/helper.ts
@@ -30,7 +30,7 @@ export async function activate(
 }
 let isLspStarted = false;
 async function waitForLspToStart(): Promise<void> {
-  await sleep(isLspStarted ? 0 : 2000);
+  await sleep(isLspStarted ? 0 : 2500);
   isLspStarted = true;
 }
 

--- a/src/test/suite/utils/helper.ts
+++ b/src/test/suite/utils/helper.ts
@@ -28,6 +28,23 @@ export async function activate(
     return null;
   }
 }
+let isLspStarted = false;
+async function waitForLspToStart(): Promise<void> {
+  await sleep(isLspStarted ? 0 : 2000);
+  isLspStarted = true;
+}
+
+export async function openDocument(
+  language: string,
+  content: string
+): Promise<void> {
+  const doc = await vscode.workspace.openTextDocument({
+    language,
+    content,
+  });
+  await vscode.window.showTextDocument(doc);
+  await waitForLspToStart();
+}
 
 async function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/test/suite/utils/testData.ts
+++ b/src/test/suite/utils/testData.ts
@@ -43,6 +43,9 @@ export const DOWNLOAD_ERROR = new Error("Download failure");
 const A_COMPLETION_PREFIX = "blabla";
 export const A_SUGGESTION = `${A_COMPLETION_PREFIX}bla`;
 const ANOTHER_SUGGESTION = `${A_COMPLETION_PREFIX}_test`;
+export const SINGLE_CHANGE_CHARACTER = "k";
+export const INLINE_PREFIX = `${A_COMPLETION_PREFIX}${SINGLE_CHANGE_CHARACTER}`;
+export const INLINE_NEW_PREFIX = `${A_COMPLETION_PREFIX}${SINGLE_CHANGE_CHARACTER}bla`;
 
 export function anEventRequest(
   name: string,


### PR DESCRIPTION
**motivation**: in the case where both a popup and the inline are visible, 'tab` key selects the popup suggestion:

**solution**: 
this pr adds the following : 
 - `lookahead` mode(the code was extracted on moved to a new file) - in this mode tabnine extends the selected  popup item and suggests a longer inline suggestion
 - the current `lookahead` suggestion is stored
 - we override the `tab` key and check if there is an active `lookahead` suggestion and accept it if any and fallback to the regular acceptance logic if there is no active `lookahead` suggestion
 
 
**before this fix**:

https://user-images.githubusercontent.com/60742964/178226600-da3a9a43-d2af-4432-8d58-bbf07f4389bb.mov 

**after this fix**:

https://user-images.githubusercontent.com/60742964/178226594-18e62b6c-e39c-461e-b175-ab89724d5735.mov


 