### PR TITLE
remove inline hint color settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,11 +320,6 @@
 						"type": "boolean",
 						"default": false,
 						"description": "Receive Tabnine VSCode extention beta updates"
-					},
-					"tabnine.inlineHintColor": {
-						"type": "string",
-						"description": "A css-compatible string that represents the inline hint color.\nFor example: black, #0a0a0a",
-						"default": null
 					}
 				}
 			}

--- a/src/inlineSuggestions/hintColor.ts
+++ b/src/inlineSuggestions/hintColor.ts
@@ -1,8 +1,0 @@
-import { workspace } from "vscode";
-
-export default function getHintColor(): string {
-  return (
-    workspace.getConfiguration().get<string>("tabnine.inlineHintColor") ||
-    "gray"
-  );
-}

--- a/src/inlineSuggestions/setInlineSuggestion.ts
+++ b/src/inlineSuggestions/setInlineSuggestion.ts
@@ -17,7 +17,6 @@ import {
   getSnippetDecorations,
   handleClearSnippetDecoration,
 } from "./snippets/snippetDecoration";
-import getHintColor from "./hintColor";
 
 const inlineDecorationType = window.createTextEditorDecorationType({});
 let showingDecoration = false;
@@ -119,7 +118,7 @@ function getOneLineDecorations(
   decorations.push({
     renderOptions: {
       after: {
-        color: getHintColor(),
+        color: "gray",
         contentText: suggestion,
         margin: `0 0 0 0`,
         textDecoration: "none; white-space: pre;",

--- a/src/inlineSuggestions/snippets/snippetDecoration.ts
+++ b/src/inlineSuggestions/snippets/snippetDecoration.ts
@@ -1,5 +1,4 @@
 import { DecorationOptions, Position, Range } from "vscode";
-import getHintColor from "../hintColor";
 import getHoverContent from "../hoverPopup";
 import { insertBlankSnippet, removeBlankSnippet } from "./blankSnippet";
 
@@ -36,7 +35,7 @@ function getDecorationFor(
   return {
     renderOptions: {
       after: {
-        color: getHintColor(),
+        color: "gray",
         contentText: line,
         margin: `0 0 0 0`,
         textDecoration: "none; white-space: pre;",


### PR DESCRIPTION
since we're using vscode's inline completions API we no longer control the color of the hint - so this settings property has no effect on the users.