### PR TITLE
fix the selected text when an inline suggestion is selected and the popup is visible

### DIFF
--- a/src/lookAheadSuggestion.ts
+++ b/src/lookAheadSuggestion.ts
@@ -5,9 +5,9 @@ import {
   InlineCompletionList,
   Position,
   SelectedCompletionInfo,
+  SnippetString,
   TextDocument,
   TextEditor,
-  TextEditorEdit,
 } from "vscode";
 import { AutocompleteResult, ResultEntry } from "./binary/requests/requests";
 import getAutoImportCommand from "./getAutoImportCommand";
@@ -81,7 +81,7 @@ function findMostRelevantSuggestion(
 function registerTabOverride(): Disposable {
   return commands.registerTextEditorCommand(
     `${TAB_OVERRIDE_COMMAND}`,
-    (_textEditor: TextEditor, edit: TextEditorEdit) => {
+    (textEditor: TextEditor) => {
       if (!currentLookAheadSuggestion) {
         void commands.executeCommand("acceptSelectedSuggestion");
         return;
@@ -89,8 +89,9 @@ function registerTabOverride(): Disposable {
 
       const { range, insertText, command } = currentLookAheadSuggestion;
       if (range && insertText && command) {
-        edit.replace(range, insertText);
-        executeSelectionCommand(command);
+        void textEditor
+          .insertSnippet(new SnippetString(insertText), range)
+          .then(() => executeSelectionCommand(command));
       }
     }
   );

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -104,6 +104,10 @@ describe("Should do completion", () => {
     await triggerSelectionAppetence();
 
     assertTextIsCommitted("console.log");
+
+    await makeAChange("o");
+
+    assertTextIsCommitted("console.logo");
   });
 });
 

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -105,11 +105,15 @@ describe("Should do completion", () => {
 
     assertTextIsCommitted("console.log");
 
-    await makeAChange("o");
-
-    assertTextIsCommitted("console.logo");
+    await makeAndAssertFollowingChange();
   });
 });
+
+async function makeAndAssertFollowingChange() {
+  await makeAChange("o");
+
+  assertTextIsCommitted("console.logo");
+}
 
 function mockInlineResponse(): void {
   mockAutocomplete(


### PR DESCRIPTION


The issue:
In the case where both inline and popup are visible and inline is accepted, the accepted text is marked as selected after selection, so any change will remove the selected area

before:
![selection-before](https://user-images.githubusercontent.com/60742964/185781049-8f4b6f28-397a-4c8d-9afb-e6106040ea5e.gif)


after:
![selection-after](https://user-images.githubusercontent.com/60742964/185781055-7a05b2fa-f3c8-467e-976b-15d0c7cb8884.gif)

