### PR TITLE
fix lookAhead dot but

### DIFF
--- a/src/lookAheadSuggestion.ts
+++ b/src/lookAheadSuggestion.ts
@@ -49,10 +49,7 @@ export async function getLookAheadSuggestion(
     2
   );
 
-  const result = findMostRelevantSuggestion(
-    response,
-    getCompletionInfoWithoutOverlappingDot(completionInfo)
-  );
+  const result = findMostRelevantSuggestion(response, completionInfo);
   const completion =
     result &&
     response &&
@@ -72,10 +69,14 @@ export async function getLookAheadSuggestion(
 
 function findMostRelevantSuggestion(
   response: AutocompleteResult | null | undefined,
-  completionInfoPrefix: string
+  completionInfo: SelectedCompletionInfo
 ): ResultEntry | undefined {
   return response?.results
-    .filter(({ new_prefix }) => new_prefix.startsWith(completionInfoPrefix))
+    .filter(({ new_prefix }) =>
+      new_prefix.startsWith(
+        getCompletionInfoWithoutOverlappingDot(completionInfo)
+      )
+    )
     .sort(
       (a, b) => parseInt(b.detail || "", 10) - parseInt(a.detail || "", 10)
     )[0];

--- a/src/lookAheadSuggestion.ts
+++ b/src/lookAheadSuggestion.ts
@@ -49,7 +49,10 @@ export async function getLookAheadSuggestion(
     2
   );
 
-  const result = findMostRelevantSuggestion(response, completionInfo);
+  const result = findMostRelevantSuggestion(
+    response,
+    getCompletionInfoWithoutOverlappingDot(completionInfo)
+  );
   const completion =
     result &&
     response &&
@@ -69,13 +72,21 @@ export async function getLookAheadSuggestion(
 
 function findMostRelevantSuggestion(
   response: AutocompleteResult | null | undefined,
-  completionInfo: SelectedCompletionInfo
+  completionInfoPrefix: string
 ): ResultEntry | undefined {
   return response?.results
-    .filter(({ new_prefix }) => new_prefix.startsWith(completionInfo.text))
+    .filter(({ new_prefix }) => new_prefix.startsWith(completionInfoPrefix))
     .sort(
       (a, b) => parseInt(b.detail || "", 10) - parseInt(a.detail || "", 10)
     )[0];
+}
+
+function getCompletionInfoWithoutOverlappingDot(
+  completionInfo: SelectedCompletionInfo
+) {
+  return completionInfo.text.startsWith(".")
+    ? completionInfo.text.substring(1)
+    : completionInfo.text;
 }
 
 function registerTabOverride(): Disposable {


### PR DESCRIPTION
fix for the following use case:
- user is typing dot (".")
- vscode shows completions (inside the popup) that don't start with "."
- the user focuses on one of those suggestions
- the SelectedCompletionInfo text contains that dot at the beginning of the completion
- we are filtering completions that have the same prefix as the SelectedCompletionInfo text, but don't find any. (since "use" != ".use")
- the user doesn't get any completion

![image (1)](https://user-images.githubusercontent.com/10290661/192806762-57f89023-221d-4dab-b0f7-b01f295ac822.png)
![image](https://user-images.githubusercontent.com/10290661/192806773-ebf975fd-3f7e-4ed2-84fb-9004138beccc.png)

the fix is to pass the SelectedCompletionInfo text to the filter function without the dot