### PR TITLE
filter the relevant change by the current position

### DIFF
--- a/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
+++ b/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
@@ -2,19 +2,26 @@ import { TextDocumentContentChangeEvent } from "vscode";
 import getTabSize from "../../binary/requests/tabSize";
 
 export default class DocumentTextChangeContent {
-  constructor(private readonly contentChange: TextDocumentContentChangeEvent) {}
+  constructor(
+    private readonly contentChange?: TextDocumentContentChangeEvent
+  ) {}
 
   isValidNonEmptyChange(): boolean {
     return (
-      this.contentChange?.rangeLength >= 0 && this.contentChange?.text !== ""
+      !!this.contentChange &&
+      this.contentChange.rangeLength >= 0 &&
+      this.contentChange.text !== ""
     );
   }
 
   isSingleCharNonWhitespaceChange(): boolean {
-    return this.contentChange?.text.trim().length <= 1;
+    return !!this.contentChange && this.contentChange?.text.trim().length <= 1;
   }
 
   isNotIndentationChange(): boolean {
-    return this.contentChange?.text !== " ".repeat(getTabSize());
+    return (
+      !!this.contentChange &&
+      this.contentChange.text !== " ".repeat(getTabSize())
+    );
   }
 }

--- a/src/inlineSuggestions/documentChangesTracker/index.ts
+++ b/src/inlineSuggestions/documentChangesTracker/index.ts
@@ -24,7 +24,11 @@ export function initTracker(): Disposable[] {
   return [
     workspace.onDidChangeTextDocument(
       ({ contentChanges }: TextDocumentChangeEvent) => {
-        const contentChange = new DocumentTextChangeContent(contentChanges[0]);
+        const currentPosition = window.activeTextEditor?.selection.active;
+        const relevantChange = contentChanges.find(
+          ({ range }) => currentPosition && range.contains(currentPosition)
+        );
+        const contentChange = new DocumentTextChangeContent(relevantChange);
         const changeHappened =
           contentChange.isValidNonEmptyChange() &&
           contentChange.isNotIndentationChange() &&


### PR DESCRIPTION
**Problem:** 
in some cases, the onDidChangeTextDocument callback is raised with multiple contentChanges causing the current change to be filtered and thus not triggering any request in this position.


**Solution:** 
the array should be filtered by the current cursor position.

<img width="677" alt="Screen Shot 2022-10-31 at 8 47 43" src="https://user-images.githubusercontent.com/60742964/198948304-9be6b5b9-bfb9-4a1c-b613-25ec38ce488b.png">
