### PR TITLE
Dev2-1649 wrong indentation in case of multine old suffix

### DIFF
--- a/src/provideInlineCompletionItems.ts
+++ b/src/provideInlineCompletionItems.ts
@@ -11,6 +11,7 @@ import {
 } from "./lookAheadSuggestion";
 import { handleFirstSuggestionDecoration } from "./firstSuggestionDecoration";
 import { SuggestionTrigger } from "./globals/consts";
+import { isMultiline } from "./utils/utils";
 
 const INLINE_REQUEST_TIMEOUT = 3000;
 const END_OF_LINE_VALID_REGEX = new RegExp("^\\s*[)}\\]\"'`]*\\s*[:{;,]?\\s*$");
@@ -83,7 +84,9 @@ function calculateRange(
 ): vscode.Range {
   return new vscode.Range(
     position.translate(0, -response.old_prefix.length),
-    position.translate(0, result.old_suffix.length)
+    isMultiline(result.old_suffix)
+      ? position
+      : position.translate(0, result.old_suffix.length)
   );
 }
 

--- a/src/test/suite/utils/completion.utils.ts
+++ b/src/test/suite/utils/completion.utils.ts
@@ -10,6 +10,8 @@ import { SelectionStateRequest } from "../../../binary/requests/setState";
 import { CompletionArguments } from "../../../CompletionArguments";
 import { sleep } from "../../../utils/utils";
 import { TAB_OVERRIDE_COMMAND } from "../../../globals/consts";
+import TabnineInlineCompletionItem from "../../../inlineSuggestions/tabnineInlineCompletionItem";
+import provideInlineCompletionItems from "../../../provideInlineCompletionItems";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 chaiUse(require("chai-shallow-deep-equal"));
@@ -114,11 +116,26 @@ export async function triggerPopupSuggestion(): Promise<void> {
   await emulationUserInteraction();
   await vscode.commands.executeCommand("editor.action.triggerSuggest");
 }
+export async function getInlineCompletions(
+  editor: vscode.TextEditor
+): Promise<vscode.InlineCompletionList<TabnineInlineCompletionItem>> {
+  return provideInlineCompletionItems(
+    editor.document,
+    editor.selection.active,
+    {
+      triggerKind: vscode.InlineCompletionTriggerKind.Automatic,
+      selectedCompletionInfo: undefined,
+    }
+  );
+}
 
-export async function openADocWith(content: string): Promise<void> {
-  await openDocument("javascript", content);
+export async function openADocWith(
+  content: string
+): Promise<vscode.TextEditor> {
+  const editor = await openDocument("javascript", content);
   await isProcessReadyForTest();
   await moveToActivePosition();
+  return editor;
 }
 
 async function moveLeftBy(value: number): Promise<void> {

--- a/src/test/suite/utils/helper.ts
+++ b/src/test/suite/utils/helper.ts
@@ -39,13 +39,14 @@ async function waitForLspToStart(): Promise<void> {
 export async function openDocument(
   language: string,
   content: string
-): Promise<void> {
+): Promise<TextEditor> {
   const doc = await vscode.workspace.openTextDocument({
     language,
     content,
   });
-  await vscode.window.showTextDocument(doc);
+  const editor = await vscode.window.showTextDocument(doc);
   await waitForLspToStart();
+  return editor;
 }
 
 export async function sleep(ms: number): Promise<number> {

--- a/src/test/suite/utils/testData.ts
+++ b/src/test/suite/utils/testData.ts
@@ -60,15 +60,17 @@ export function aNotificationId(): string {
 
 export function anAutocompleteResponse(
   oldPrefix?: string,
-  newPrefix?: string
+  newPrefix?: string,
+  oldSuffix = "",
+  newSuffix = ""
 ): AutocompleteResult {
   return {
     old_prefix: oldPrefix !== undefined ? oldPrefix : A_COMPLETION_PREFIX,
     results: [
       {
         new_prefix: newPrefix !== undefined ? newPrefix : A_SUGGESTION,
-        old_suffix: "",
-        new_suffix: "",
+        old_suffix: oldSuffix,
+        new_suffix: newSuffix,
         origin: CompletionOrigin.VANILLA,
       },
       {


### PR DESCRIPTION
**problem:** 
in some cases, the binary  returns multiline `old_suffix` which is probably another issue that should be investigated

![Screen Shot 2022-11-08 at 9 59 31](https://user-images.githubusercontent.com/60742964/200540293-ae95c746-cb40-48ef-94fa-3579c4f2dd3c.png)


the solution in this pr is to modify the [replace range](https://github.com/codota/tabnine-vscode/blob/a12abaf4d511c67d1af69bdc9692995a12c0619f/src/vscode.proposed.inlineCompletions.d.ts#L105) only in case of a single  line which  should handle closing brackets that should be replaced

