### PR TITLE
DEV2-1677 check for tab-in in languages with tab indentation vs. spaces

### DIFF
--- a/src/binary/requests/tabSize.ts
+++ b/src/binary/requests/tabSize.ts
@@ -7,3 +7,6 @@ export default function getTabSize(): number {
   }
   return tabSize;
 }
+export function getTabsCount(): number {
+  return getTabSize() / getTabSize();
+}

--- a/src/binary/requests/tabSize.ts
+++ b/src/binary/requests/tabSize.ts
@@ -8,5 +8,5 @@ export default function getTabSize(): number {
   return tabSize;
 }
 export function getTabsCount(): number {
-  return getTabSize() / getTabSize();
+  return getTabSize() / 4;
 }

--- a/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
+++ b/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
@@ -1,5 +1,5 @@
 import { TextDocumentContentChangeEvent } from "vscode";
-import getTabSize from "../../binary/requests/tabSize";
+import getTabSize, { getTabsCount } from "../../binary/requests/tabSize";
 
 export default class DocumentTextChangeContent {
   constructor(
@@ -21,7 +21,8 @@ export default class DocumentTextChangeContent {
   isNotIndentationChange(): boolean {
     return (
       !!this.contentChange &&
-      this.contentChange.text !== " ".repeat(getTabSize())
+      this.contentChange.text !== " ".repeat(getTabSize()) &&
+      this.contentChange.text !== "\t".repeat(getTabsCount())
     );
   }
 }

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -178,19 +178,10 @@ describe("Should do completion", () => {
     ).never();
   });
   it("should skip completion request on Tab key (indention in)", async () => {
-    await openADocWith("");
-
-    await emulationUserInteraction();
-
-    await vscode.commands.executeCommand("tab");
-
-    await triggerInline();
-
-    await emulationUserInteraction();
-
-    verify(
-      stdinMock.write(new SimpleAutocompleteRequestMatcher(), "utf8")
-    ).never();
+    await runSkipIndentInTest("javascript");
+  });
+  it("should skip completion request on Tab key (indention in) in golang where indentation is \t", async () => {
+    await runSkipIndentInTest("go");
   });
   it("should suggest completions on new line ", async () => {
     await openADocWith("console.log");
@@ -249,6 +240,21 @@ describe("Should do completion", () => {
     );
   });
 });
+
+async function runSkipIndentInTest(language: string): Promise<void> {
+  await openADocWith("", language);
+  await emulationUserInteraction();
+
+  await vscode.commands.executeCommand("tab");
+
+  await triggerInline();
+
+  await emulationUserInteraction();
+
+  verify(
+    stdinMock.write(new SimpleAutocompleteRequestMatcher(), "utf8")
+  ).never();
+}
 
 async function makeAndAssertFollowingChange() {
   await makeAChange("o");

--- a/src/test/suite/utils/completion.utils.ts
+++ b/src/test/suite/utils/completion.utils.ts
@@ -130,9 +130,10 @@ export async function getInlineCompletions(
 }
 
 export async function openADocWith(
-  content: string
+  content: string,
+  language = "javascript"
 ): Promise<vscode.TextEditor> {
-  const editor = await openDocument("javascript", content);
+  const editor = await openDocument(language, content);
   await isProcessReadyForTest();
   await moveToActivePosition();
   return editor;


### PR DESCRIPTION
**problem:**
in the case of "tab" indentation (`\t`), the change detection was expecting only spaces `" "` and not tab indentation