### PR TITLE
DEV2-1677 fix tab-indent for first tab

### DIFF
--- a/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
+++ b/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
@@ -22,7 +22,8 @@ export default class DocumentTextChangeContent {
     return (
       !!this.contentChange &&
       this.contentChange.text !== " ".repeat(getTabSize()) &&
-      this.contentChange.text !== "\t".repeat(getTabsCount())
+      this.contentChange.text !==
+        "\t".repeat(getTabsCount() * (1 + this.contentChange.rangeLength))
     );
   }
 }


### PR DESCRIPTION
in some cases, the first indentation tab will fire with "range to replace" =  1 and change = "\t\t" meaning it would replace the existing one tab with 2

![Screen Shot 2022-11-10 at 17 19 22](https://user-images.githubusercontent.com/60742964/201134755-4085926a-9fb9-449b-9655-6d5e54662550.png)
