### PR TITLE
DEV2-1736 apply python indentation extension fix

### DIFF
--- a/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
+++ b/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
@@ -1,8 +1,9 @@
-import { TextDocumentContentChangeEvent } from "vscode";
+import { TextDocument, TextDocumentContentChangeEvent } from "vscode";
 import getTabSize from "../../binary/requests/tabSize";
 
 export default class DocumentTextChangeContent {
   constructor(
+    private readonly document: TextDocument,
     private readonly contentChange?: TextDocumentContentChangeEvent
   ) {}
 
@@ -27,6 +28,15 @@ export default class DocumentTextChangeContent {
     return (
       !!this.contentChange &&
       (isNewLine || (!isEndsWithWhitespace && !isEndsWithTab))
+    );
+  }
+
+  isPythonNewLineChange(): boolean {
+    return (
+      !!this.contentChange &&
+      this.document.languageId === "python" &&
+      this.contentChange?.text.startsWith("\n") &&
+      this.contentChange?.text.trim() === ""
     );
   }
 }

--- a/src/inlineSuggestions/documentChangesTracker/index.ts
+++ b/src/inlineSuggestions/documentChangesTracker/index.ts
@@ -1,5 +1,6 @@
 import { Disposable, TextDocumentChangeEvent, window, workspace } from "vscode";
 import DocumentTextChangeContent from "./DocumentTextChangeContent";
+import tryApplyPythonIndentExtensionFix from "./pythonIndentExtensionFix";
 
 let shouldComplete = false;
 let change = false;
@@ -23,18 +24,22 @@ export function getShouldComplete(): boolean {
 export function initTracker(): Disposable[] {
   return [
     workspace.onDidChangeTextDocument(
-      ({ contentChanges }: TextDocumentChangeEvent) => {
+      ({ contentChanges, document }: TextDocumentChangeEvent) => {
         const currentPosition = window.activeTextEditor?.selection.active;
         const relevantChange = contentChanges.find(
           ({ range }) => currentPosition && range.contains(currentPosition)
         );
-        const contentChange = new DocumentTextChangeContent(relevantChange);
+        const contentChange = new DocumentTextChangeContent(
+          document,
+          relevantChange
+        );
         const changeHappened =
           contentChange.isValidNonEmptyChange() &&
           contentChange.isNotIndentationChange() &&
           contentChange.isSingleCharNonWhitespaceChange();
         if (changeHappened) {
           onChange();
+          tryApplyPythonIndentExtensionFix(contentChange);
         }
       }
     ),

--- a/src/inlineSuggestions/documentChangesTracker/pythonIndentExtensionFix.ts
+++ b/src/inlineSuggestions/documentChangesTracker/pythonIndentExtensionFix.ts
@@ -1,0 +1,19 @@
+import { commands, extensions } from "vscode";
+import DocumentTextChangeContent from "./DocumentTextChangeContent";
+
+const PYTHON_INDENT_EXTENSION_ID = "KevinRose.vsc-python-indent";
+
+function isPythonIndentExtensionEnabled() {
+  return extensions.all.find((x) => x.id.includes(PYTHON_INDENT_EXTENSION_ID))
+    ?.isActive;
+}
+export default function tryApplyPythonIndentExtensionFix(
+  contentChange: DocumentTextChangeContent
+): void {
+  if (
+    contentChange.isPythonNewLineChange() &&
+    isPythonIndentExtensionEnabled()
+  ) {
+    void commands.executeCommand("editor.action.inlineSuggest.trigger");
+  }
+}

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -177,7 +177,7 @@ describe("Should do completion", () => {
       stdinMock.write(new SimpleAutocompleteRequestMatcher(), "utf8")
     ).never();
   });
-  it.only("should skip completion request on Tab key (indention in)", async () => {
+  it("should skip completion request on Tab key (indention in)", async () => {
     const jsBlock = `function test() {
     
 }`;
@@ -194,6 +194,18 @@ describe("Should do completion", () => {
       `);
 
     await triggerInline();
+
+    await emulationUserInteraction();
+
+    verify(
+      stdinMock.write(new SimpleAutocompleteRequestMatcher(), "utf8")
+    ).once();
+  });
+  it("should do completion on new line in python", async () => {
+    await openADocWith("def binary_search(arr, target):", "python");
+    await moveToActivePosition();
+
+    await makeAChange(`\n`);
 
     await emulationUserInteraction();
 


### PR DESCRIPTION
**Problem:**
if [vsc-python-indent](https://github.com/kbrose/vsc-python-indent)  is installed, this extension  is  overrides the "enter" key biding and creates an `edit.insert`   https://github.com/kbrose/vsc-python-indent/blob/47a0c164f44fce0d82f6c7f16fd844626914273f/src/indent.ts#L54

for some reason, if the edit starts with `\n` the provideInlineCompletionItems handler is not triggered (probably due to some vscode issue).

**Solution:** as a workaround in this case we will check if the edit is in a python file and the edit starts with `\n` and `vsc-python-indent` is enabled,  we will trigger the `provideInlineCompletionItems`