### PR TITLE
DEV2-1254 do not change the order of the suggestions

### DIFF
--- a/src/lookAheadSuggestion.ts
+++ b/src/lookAheadSuggestion.ts
@@ -76,15 +76,11 @@ function findMostRelevantSuggestion(
   response: AutocompleteResult | null | undefined,
   completionInfo: SelectedCompletionInfo
 ): ResultEntry | undefined {
-  return response?.results
-    .filter(({ new_prefix }) =>
-      new_prefix.startsWith(
-        getCompletionInfoWithoutOverlappingDot(completionInfo)
-      )
+  return response?.results.find(({ new_prefix }) =>
+    new_prefix.startsWith(
+      getCompletionInfoWithoutOverlappingDot(completionInfo)
     )
-    .sort(
-      (a, b) => parseInt(b.detail || "", 10) - parseInt(a.detail || "", 10)
-    )[0];
+  );
 }
 
 function getCompletionInfoWithoutOverlappingDot(


### PR DESCRIPTION
the order is handled by Tabnine engine(binary), the returned suggestions are ordered by the probability + length, so there is no need to reorder them, the only thing that should be handled is prefix matching.

ref https://tabnine.atlassian.net/browse/DEV2-1254