### PR TITLE
DEV2-1763  - accept suggestion  with tab indentation  is not working 

### DIFF
--- a/package.json
+++ b/package.json
@@ -337,6 +337,11 @@
 				"when": "tabnine.tab-override && suggestWidgetVisible && textInputFocus"
 			},
 			{
+				"key": "tab",
+				"command": "editor.action.inlineSuggest.commit",
+				"when": "tabnine.tab-override && inlineSuggestionVisible && !editorTabMovesFocus"
+			},
+			{
 				"key": "escape",
 				"command": "tabnine.escape-inline-suggestion",
 				"when": "tabnine.snippet-suggestion:enabled && tabnine.in-inline-suggestions || tabnine.inline-suggestion:enabled && tabnine.in-inline-suggestions"

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -38,6 +38,7 @@ import { AutocompleteRequestMatcher } from "./utils/AutocompleteRequestMatcher";
 import { resetBinaryForTesting } from "../../binary/requests/requests";
 import { sleep } from "../../utils/utils";
 import { SimpleAutocompleteRequestMatcher } from "./utils/SimpleAutocompleteRequestMatcher";
+import getTabSize from "../../binary/requests/tabSize";
 
 describe("Should do completion", () => {
   const docUri = getDocUri("completion.txt");
@@ -253,6 +254,28 @@ describe("Should do completion", () => {
     ).to.deep.equal(
       editor.selection.active.translate(0, singleLineSuffix.length)
     );
+  });
+  it.only("should accept completion with indentation ", async () => {
+    const INDENTED_SUGGESTION = "    return false;";
+    const CURRENT_INDENTATION = " ".repeat(getTabSize());
+    mockAutocomplete(
+      requestResponseItems,
+      anAutocompleteResponse("", INDENTED_SUGGESTION)
+    );
+    await openADocWith("function test(){");
+    await moveToActivePosition();
+
+    await vscode.commands.executeCommand("type", { text: "\n" });
+
+    await emulationUserInteraction();
+
+    await acceptInline();
+
+    expect(
+      vscode.window.activeTextEditor?.document.lineAt(
+        vscode.window.activeTextEditor.selection.active
+      ).text
+    ).to.equal(`${CURRENT_INDENTATION}${INDENTED_SUGGESTION}`);
   });
 });
 


### PR DESCRIPTION
**problem:**
vscode's builtin  `editor.action.inlineSuggest.commit` is not triggered if the current suggestion has an indentation greater than `tab`https://github.com/microsoft/vscode/blob/45b5568e7d351bb75f2930f48b1978a4df016b84/src/vs/editor/contrib/inlineCompletions/browser/ghostTextController.ts

in our case there are suggestions with indentation that can greater than tab :


![Screen Shot 2022-11-23 at 18 16 12](https://user-images.githubusercontent.com/60742964/203595839-35622d60-5b25-4896-ac3b-2cfc7b4a9bbe.png)

**Solution:** override the 'tab' keyword and trigger the builtin `editor.action.inlineSuggest.commit` command 

