### PR TITLE
Dev2 1539 - support indentation-out  backspace change

### DIFF
--- a/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
+++ b/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
@@ -43,6 +43,7 @@ export default class DocumentTextChangeContent {
   isIndentOutChange(): boolean {
     return (
       !!this.contentChange &&
+      // in case of /t the rangeLength will be 1, in case of spaces the rangeLength will be tabsize
       this.contentChange.rangeLength > 0 &&
       this.document.lineAt(this.contentChange.range.end).isEmptyOrWhitespace
     );

--- a/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
+++ b/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
@@ -39,4 +39,12 @@ export default class DocumentTextChangeContent {
       this.contentChange?.text.trim() === ""
     );
   }
+
+  isIndentOutChange(): boolean {
+    return (
+      !!this.contentChange &&
+      this.contentChange.rangeLength > 0 &&
+      this.document.lineAt(this.contentChange.range.end).isEmptyOrWhitespace
+    );
+  }
 }

--- a/src/inlineSuggestions/documentChangesTracker/index.ts
+++ b/src/inlineSuggestions/documentChangesTracker/index.ts
@@ -34,9 +34,11 @@ export function initTracker(): Disposable[] {
           relevantChange
         );
         const changeHappened =
-          contentChange.isValidNonEmptyChange() &&
-          contentChange.isNotIndentationChange() &&
-          contentChange.isSingleCharNonWhitespaceChange();
+          (contentChange.isValidNonEmptyChange() &&
+            contentChange.isNotIndentationChange() &&
+            contentChange.isSingleCharNonWhitespaceChange()) ||
+          contentChange.isIndentOutChange();
+
         if (changeHappened) {
           onChange();
           tryApplyPythonIndentExtensionFix(contentChange);

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -278,18 +278,20 @@ describe("Should do completion", () => {
     ).to.equal(`${CURRENT_INDENTATION}${INDENTED_SUGGESTION}`);
   });
 
-  ["    ", "\t"].forEach((indentation) => {
-    it.only("should trigger suggestions on indentation out (backspace)", async () => {
-      await openADocWith(indentation);
-      await moveToActivePosition();
-      await vscode.commands.executeCommand("deleteLeft");
-      await emulationUserInteraction();
+  [{ indentation: "    " }, { indentation: "\t" }].forEach(
+    ({ indentation }) => {
+      it.only(`should trigger suggestions on indentation of type "${indentation}" out (backspace)`, async () => {
+        await openADocWith(indentation);
+        await moveToActivePosition();
+        await vscode.commands.executeCommand("deleteLeft");
+        await emulationUserInteraction();
 
-      verify(
-        stdinMock.write(new SimpleAutocompleteRequestMatcher(), "utf8")
-      ).once();
-    });
-  });
+        verify(
+          stdinMock.write(new SimpleAutocompleteRequestMatcher(), "utf8")
+        ).once();
+      });
+    }
+  );
 });
 
 async function runSkipIndentInTest(

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -42,6 +42,8 @@ import getTabSize from "../../binary/requests/tabSize";
 
 describe("Should do completion", () => {
   const docUri = getDocUri("completion.txt");
+  const SPACES_INDENTATION = "    ";
+  const TAB_INDENTATION = "\t";
 
   beforeEach(async () => {
     await activate(docUri);
@@ -277,21 +279,18 @@ describe("Should do completion", () => {
       ).text
     ).to.equal(`${CURRENT_INDENTATION}${INDENTED_SUGGESTION}`);
   });
+  [SPACES_INDENTATION, TAB_INDENTATION].forEach((indentation) => {
+    it.only(`should trigger suggestions on indentation of type "${indentation}" out (backspace)`, async () => {
+      await openADocWith(indentation);
+      await moveToActivePosition();
+      await vscode.commands.executeCommand("deleteLeft");
+      await emulationUserInteraction();
 
-  [{ indentation: "    " }, { indentation: "\t" }].forEach(
-    ({ indentation }) => {
-      it.only(`should trigger suggestions on indentation of type "${indentation}" out (backspace)`, async () => {
-        await openADocWith(indentation);
-        await moveToActivePosition();
-        await vscode.commands.executeCommand("deleteLeft");
-        await emulationUserInteraction();
-
-        verify(
-          stdinMock.write(new SimpleAutocompleteRequestMatcher(), "utf8")
-        ).once();
-      });
-    }
-  );
+      verify(
+        stdinMock.write(new SimpleAutocompleteRequestMatcher(), "utf8")
+      ).once();
+    });
+  });
 });
 
 async function runSkipIndentInTest(

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -277,6 +277,19 @@ describe("Should do completion", () => {
       ).text
     ).to.equal(`${CURRENT_INDENTATION}${INDENTED_SUGGESTION}`);
   });
+
+  ["    ", "\t"].forEach((indentation) => {
+    it.only("should trigger suggestions on indentation out (backspace)", async () => {
+      await openADocWith(indentation);
+      await moveToActivePosition();
+      await vscode.commands.executeCommand("deleteLeft");
+      await emulationUserInteraction();
+
+      verify(
+        stdinMock.write(new SimpleAutocompleteRequestMatcher(), "utf8")
+      ).once();
+    });
+  });
 });
 
 async function runSkipIndentInTest(


### PR DESCRIPTION
the purpose of this pr is to enable suggestions for "indentation-out" (backspace) this is relevant manly in python 

before the fix:
![beffore-indentation](https://user-images.githubusercontent.com/60742964/203732712-a990d066-b390-4723-a56b-96e8f71dd2a8.gif)

after the fix:

![beffore-indentation-after](https://user-images.githubusercontent.com/60742964/203733079-4b7eb4aa-1c8d-47a5-b35c-9d3f76aff8d5.gif)

