### PR TITLE
DEV2-1812

### DIFF
--- a/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
+++ b/src/inlineSuggestions/documentChangesTracker/DocumentTextChangeContent.ts
@@ -1,6 +1,7 @@
 import { TextDocument, TextDocumentContentChangeEvent } from "vscode";
 import getTabSize from "../../binary/requests/tabSize";
 
+const AUTO_CLOSED_BRACKETS_CHANGE = ["()", "{}", "[]", '""', "''", "``"];
 export default class DocumentTextChangeContent {
   constructor(
     private readonly document: TextDocument,
@@ -16,7 +17,11 @@ export default class DocumentTextChangeContent {
   }
 
   isSingleCharNonWhitespaceChange(): boolean {
-    return !!this.contentChange && this.contentChange?.text.trim().length <= 1;
+    return (
+      !!this.contentChange &&
+      (this.contentChange?.text.trim().length <= 1 ||
+        AUTO_CLOSED_BRACKETS_CHANGE.includes(this.contentChange.text))
+    );
   }
 
   isNotIndentationChange(): boolean {

--- a/src/lookAheadSuggestion.ts
+++ b/src/lookAheadSuggestion.ts
@@ -8,6 +8,7 @@ import {
   SnippetString,
   TextDocument,
   TextEditor,
+  window,
 } from "vscode";
 import { AutocompleteResult, ResultEntry } from "./binary/requests/requests";
 import getAutoImportCommand from "./getAutoImportCommand";
@@ -29,6 +30,8 @@ export async function initTabOverride(
   subscriptions.push(await enableTabOverrideContext(), registerTabOverride());
 }
 
+window.onDidChangeTextEditorSelection(clearCurrentLookAheadSuggestion);
+
 // "look a head " suggestion
 // is the suggestion witch extends te current selected intellisense popup item
 // and queries tabnine with the selected item as prefix untitled-file-extension
@@ -37,6 +40,14 @@ export async function getLookAheadSuggestion(
   completionInfo: SelectedCompletionInfo,
   position: Position
 ): Promise<InlineCompletionList<TabnineInlineCompletionItem>> {
+  const isContainsCompletionInfo = completionInfo.text.startsWith(
+    document.getText(completionInfo.range)
+  );
+
+  if (!isContainsCompletionInfo) {
+    return new InlineCompletionList([]);
+  }
+
   const response = await retry(
     () =>
       runCompletion(

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -291,6 +291,18 @@ describe("Should do completion", () => {
       ).once();
     });
   });
+  it.only("should should query tabnine if the change is auto closed brackets", async () => {
+    await openADocWith("console.log", "javascript");
+    await moveToActivePosition();
+    await vscode.commands.executeCommand("type", {
+      text: "(",
+    });
+    await sleep(400);
+
+    verify(
+      stdinMock.write(new SimpleAutocompleteRequestMatcher(), "utf8")
+    ).atLeast(1);
+  });
 });
 
 async function runSkipIndentInTest(

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -303,6 +303,19 @@ describe("Should do completion", () => {
       stdinMock.write(new SimpleAutocompleteRequestMatcher(), "utf8")
     ).atLeast(1);
   });
+  it("should not try to suggest if the prefix is not matching the focused item", async () => {
+    await openADocWith("function test(){ֿ\n  rtu", "javascript");
+    await emulationUserInteraction();
+    await vscode.commands.executeCommand("cursorBottom");
+    await vscode.commands.executeCommand("type", {
+      text: "n",
+    });
+
+    await emulationUserInteraction();
+    verify(
+      stdinMock.write(new SimpleAutocompleteRequestMatcher("return"), "utf8")
+    ).never();
+  });
 });
 
 async function runSkipIndentInTest(

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -291,7 +291,7 @@ describe("Should do completion", () => {
       ).once();
     });
   });
-  it.only("should should query tabnine if the change is auto closed brackets", async () => {
+  it("should should query tabnine if the change is auto closed brackets", async () => {
     await openADocWith("console.log", "javascript");
     await moveToActivePosition();
     await vscode.commands.executeCommand("type", {

--- a/src/test/suite/utils/SimpleAutocompleteRequestMatcher.ts
+++ b/src/test/suite/utils/SimpleAutocompleteRequestMatcher.ts
@@ -4,6 +4,10 @@ import { AutocompleteRequest } from "./completion.utils";
 
 // eslint-disable-next-line import/prefer-default-export
 export class SimpleAutocompleteRequestMatcher extends Matcher {
+  constructor(private prefix = "") {
+    super();
+  }
+
   // eslint-disable-next-line  class-methods-use-this
   match(request: string): boolean {
     const completionRequest = JSON.parse(request) as AutocompleteRequest;
@@ -11,7 +15,8 @@ export class SimpleAutocompleteRequestMatcher extends Matcher {
     return (
       request.endsWith("\n") &&
       completionRequest?.version === API_VERSION &&
-      !!completionRequest?.request?.Autocomplete
+      !!completionRequest?.request?.Autocomplete &&
+      completionRequest?.request?.Autocomplete.before.endsWith(this.prefix)
     );
   }
 


### PR DESCRIPTION
this pr handles 2 issues:
 - support suggestion if the current change contains auto-closed  brackets 
 -  do not query tabnine if the focused popup item  is not equal to the prefix (see the screenshot):


![Screen Shot 2022-12-01 at 18 02 20](https://user-images.githubusercontent.com/60742964/205102239-7a3f404d-6247-45a4-a4f2-78bf1aca2da7.png)
