### PR TITLE
DEV2-2907 fix login notification raise

### DIFF
--- a/src/enterprise/requests/UserInfo.ts
+++ b/src/enterprise/requests/UserInfo.ts
@@ -1,6 +1,6 @@
 import { tabNineProcess } from "../../binary/requests/requests";
 
-type UserInfo = {
+export type UserInfo = {
   email: string;
   team: [];
   verified: [];


### PR DESCRIPTION
check if the user is logged in via the `UserInfo` request instead of the `authentication.getSession` which is inited later
 