### PR TITLE
DEV2-3026: Copy configuration from updater extension

### DIFF
--- a/src/enterprise/extension.ts
+++ b/src/enterprise/extension.ts
@@ -21,7 +21,11 @@ import { tryToUpdate } from "./tryToUpdate";
 import serverUrl from "./update/serverUrl";
 import tabnineExtensionProperties from "../globals/tabnineExtensionProperties";
 import { host } from "../utils/utils";
-import { RELOAD_COMMAND, TABNINE_HOST_CONFIGURATION } from "./consts";
+import {
+  RELOAD_COMMAND,
+  SELF_HOSTED_SERVER_CONFIGURATION,
+  TABNINE_HOST_CONFIGURATION,
+} from "./consts";
 import TabnineAuthenticationProvider from "../authentication/TabnineAuthenticationProvider";
 import { BRAND_NAME, ENTERPRISE_BRAND_NAME } from "../globals/consts";
 import { StatusBar } from "./statusBar";
@@ -42,6 +46,8 @@ export async function activate(
       void uninstallGATabnineIfPresent();
     })
   );
+
+  await copyServerUrlFromUpdater();
   if (!tryToUpdate()) {
     void confirmServerUrl();
     context.subscriptions.push(
@@ -142,5 +148,25 @@ async function uninstallGATabnineIfPresent() {
       // the user didn't give consent
       // should be some a warning bar or other indication of conflict - waiting for Dima to fix status bar before proceeding
     }
+  }
+}
+
+async function copyServerUrlFromUpdater(): Promise<void> {
+  const currentConfiguration = await vscode.workspace
+    .getConfiguration()
+    .get(TABNINE_HOST_CONFIGURATION);
+
+  if (currentConfiguration) {
+    return;
+  }
+
+  const updaterConfig = await vscode.workspace
+    .getConfiguration()
+    .get(SELF_HOSTED_SERVER_CONFIGURATION);
+
+  if (typeof updaterConfig === "string" && updaterConfig.length > 0) {
+    await vscode.workspace
+      .getConfiguration()
+      .update(TABNINE_HOST_CONFIGURATION, updaterConfig, true);
   }
 }

--- a/src/enterprise/statusBar/StatusBar.ts
+++ b/src/enterprise/statusBar/StatusBar.ts
@@ -111,7 +111,7 @@ export class StatusBar implements Disposable {
   }
 
   private setReady() {
-    showSuceessNotification();
+    showSuccessNotification();
     this.setDefaultStatus();
     this.statusPollingInterval = setInterval(() => {
       void getState().then(
@@ -139,7 +139,7 @@ export class StatusBar implements Disposable {
   }
 }
 
-function showSuceessNotification() {
+function showSuccessNotification() {
   void window.showInformationMessage(
     "Congratulations! Tabnine is up and running."
   );

--- a/src/enterprise/update/serverUrl.ts
+++ b/src/enterprise/update/serverUrl.ts
@@ -12,7 +12,6 @@ export default function serverUrl(): string | undefined {
     workspace.getConfiguration().get<string>(TABNINE_HOST_CONFIGURATION) ||
     oldUrl;
 
-  validateUrl(url);
   return url;
 }
 export function validateUrl(url: string | undefined): boolean {


### PR DESCRIPTION
From the code (and testing), it seems that the user doesn’t actually need to set it twice because it is looking at the other value as well. But if the user clicks on the settings, the cloud URL seems empty. So we will copy the settings if not set (so we won't override it)