### PR TITLE
DEV2-3247 - Fix: Startup Issue in devcontainers

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,10 @@
   "activationEvents": [
     "*"
   ],
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
   "main": "./out/extension",
   "scripts": {
     "analyze:bundle": "webpack --env analyzeBundle",


### PR DESCRIPTION
Extension was failing to initialize correctly when launched in [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers). Upon investigating, it appears that users needed to manually input certain settings to workaround this issue.

To enable the Tabnine extension to work with devcontainers, users [have been required to add the following settings](https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location) to their VSCode settings.json:

```jsonc
// VSCode user's settings.json
{
  "remote.extensionKind": {
    "TabNine.tabnine-vscode": [
      "ui",
      "workspace"
    ]
  }
}

```

Considering the complexity and inconvenience this imposes on users, I've prepared this PR to address and resolve the issue.
