### PR TITLE
DEV2-3537: Remove all other extensions that user might have

### DIFF
--- a/src/enterprise/extension.ts
+++ b/src/enterprise/extension.ts
@@ -161,7 +161,7 @@ async function uninstallOtherTabnineIfPresent(extensionIds: string[]) {
           } catch (e) {
             Logger.warn(
               `Error while removing extension ${
-                (oldExtension as vscode.Extension<any>).id
+                (oldExtension as vscode.Extension<unknown>).id
               }: ${(e as Error).message}`
             );
             return false;


### PR DESCRIPTION
This PR makes the updater/self hosted extension which is `tabnine-vscode-self-hosted-updater` to remove both GA and the now deprecated enterprise extnsion 