### PR TITLE
DEV2-4342 fix tabnine.enterprise key

### DIFF
--- a/src/enterprise/extension.ts
+++ b/src/enterprise/extension.ts
@@ -34,7 +34,7 @@ import TabnineAuthenticationProvider from "../authentication/TabnineAuthenticati
 import {
   BRAND_NAME,
   ENTERPRISE_BRAND_NAME,
-  TABNINE_ENTERPRISE_KEY,
+  IS_SELF_HOSTED_CONTEXT_KEY,
 } from "../globals/consts";
 import { StatusBar } from "./statusBar";
 import { isHealthyServer } from "./update/isHealthyServer";
@@ -45,6 +45,8 @@ import confirmReload from "./update/confirmReload";
 import SignInUsingCustomTokenCommand from "../authentication/loginWithCustomTokenCommand";
 import { SIGN_IN_AUTH_TOKEN_COMMAND } from "../commandsHandler";
 import { WorkspaceUpdater } from "../WorkspaceUpdater";
+
+const TABNINE_ENTERPISE_CONTEXT_KEY = "tabnine.enterprise";
 
 export async function activate(
   context: vscode.ExtensionContext
@@ -119,16 +121,16 @@ async function setEnterpriseContext(
 ): Promise<vscode.Disposable> {
   await vscode.commands.executeCommand(
     "setContext",
-    TABNINE_ENTERPRISE_KEY,
+    TABNINE_ENTERPISE_CONTEXT_KEY,
     true
   );
-  await context.workspaceState.update(TABNINE_ENTERPRISE_KEY, true);
+  await context.workspaceState.update(IS_SELF_HOSTED_CONTEXT_KEY, true);
 
   return new vscode.Disposable(() => {
-    void context.workspaceState.update(TABNINE_ENTERPRISE_KEY, undefined);
+    void context.workspaceState.update(IS_SELF_HOSTED_CONTEXT_KEY, undefined);
     void vscode.commands.executeCommand(
       "setContext",
-      TABNINE_ENTERPRISE_KEY,
+      TABNINE_ENTERPISE_CONTEXT_KEY,
       undefined
     );
   });

--- a/src/globals/consts.ts
+++ b/src/globals/consts.ts
@@ -178,4 +178,4 @@ export enum SuggestionTrigger {
 }
 
 export const TLS_CONFIG_MIN_SUPPORTED_VERSION = "4.22.0";
-export const TABNINE_ENTERPRISE_KEY = "tabnine.enterprise";
+export const IS_SELF_HOSTED_CONTEXT_KEY = "tabnine.isSelfHosted";

--- a/src/tabnineChatWidget/ChatApi.ts
+++ b/src/tabnineChatWidget/ChatApi.ts
@@ -15,7 +15,7 @@ import { peekDefinition } from "./handlers/peekDefinition";
 import { ServiceLevel } from "../binary/state";
 import {
   GET_CHAT_STATE_COMMAND,
-  TABNINE_ENTERPRISE_KEY,
+  IS_SELF_HOSTED_CONTEXT_KEY,
 } from "../globals/consts";
 import {
   BasicContext,
@@ -122,7 +122,10 @@ export function initChatApi(
         ].includes(vscode.window.activeColorTheme.kind),
         isTelemetryEnabled: isCapabilityEnabled(Capability.ALPHA_CAPABILITY),
         serverUrl,
-        isSelfHosted: context.workspaceState.get(TABNINE_ENTERPRISE_KEY, false),
+        isSelfHosted: context.workspaceState.get(
+          IS_SELF_HOSTED_CONTEXT_KEY,
+          false
+        ),
       });
     })
     .registerEvent<void, GetUserResponse>("get_user", async () => {


### PR DESCRIPTION
this line from the CI fails the build: 
[`test "$(cat temp/extension/out/extension.js | grep tabnine.enterprise | wc -l)" = "0"`](https://github.com/codota/tabnine-vscode/blob/03d842eb384a3a9b3af3410a9fc7a1c9304986a4/.github/workflows/tag.yml#L69) 
because I added `"tabnine.enterprise"` to the non-enterprise plugin in this line:
[`isSelfHosted: context.workspaceState.get(TABNINE_ENTERPRISE_KEY, false),`](https://github.com/codota/tabnine-vscode/blob/03d842eb384a3a9b3af3410a9fc7a1c9304986a4/src/tabnineChatWidget/ChatApi.ts#L125) 🤦🏻 

### Solution
change the key that's used in the non-enterprise plugin to `tabnine.isSelfHosted` 🤦🏻 

### Proof it works
I built the extension locally from this branch and ran the line from the CI:
```
➜  tabnine-vscode git:(DEV2-4342-fix-release) ✗ test "$(cat temp/extension/out/extension.js | grep tabnine.enterprise | wc -l)" = "0"
➜  tabnine-vscode git:(DEV2-4342-fix-release) ✗ echo $?
0
```