### PR TITLE
Check access token before firing auth change event

### DIFF
--- a/src/authentication/TabnineAuthenticationProvider.ts
+++ b/src/authentication/TabnineAuthenticationProvider.ts
@@ -134,7 +134,7 @@ export default class TabnineAuthenticationProvider
       });
     }
 
-    if (last && current) {
+    if (last && current && last.accessToken !== current.accessToken) {
       this.sessionsChangeEventEmitter.fire({
         removed: [toSession(last)],
         added: [toSession(current)],


### PR DESCRIPTION
I've recently noticed an issue with the tabnine extension in [Eclipse Theia](https://github.com/eclipse-theia/theia), see https://github.com/eclipse-theia/theia/issues/13336. I've tracked the issue down to a call to [`getState`](https://github.com/msujew/tabnine-vscode/blob/80ec9493f32dcc95d0a8abeaca124f2a31e25388/src/binary/requests/requests.ts#L113-L117), which incorrectly fires the auth session change event, even though no login information has changed (some other, state related information changed, but the auth info was the same). I couldn't figure out why the extension behaves differently in vscode vs Theia, since both send the exact same events to the extension.

Instead, this change prevents the session change event from firing in case the access token didn't change. I've confirmed that this fixes the issue in Theia and as far as I could tell doesn't introduce any regression in vscode.